### PR TITLE
Refactor read request

### DIFF
--- a/basis/furnace/actions/actions-tests.factor
+++ b/basis/furnace/actions/actions-tests.factor
@@ -1,4 +1,4 @@
-USING: kernel furnace.actions validators tools.test math math.parser
+USING: kernel furnace.actions io.crlf validators tools.test math math.parser
 multiline namespaces http io.streams.string http.server http.server.requests
 sequences splitting accessors ;
 IN: furnace.actions.tests
@@ -6,8 +6,6 @@ IN: furnace.actions.tests
 <action>
     [ "a" param "b" param [ string>number ] bi@ + ] >>display
 "action-1" set
-
-: lf>crlf ( string -- string' ) "\n" split "\r\n" join ;
 
 STRING: action-request-test-1
 GET http://foo/bar?a=12&b=13 HTTP/1.1

--- a/basis/furnace/actions/actions-tests.factor
+++ b/basis/furnace/actions/actions-tests.factor
@@ -1,6 +1,6 @@
-USING: kernel furnace.actions validators
-tools.test math math.parser multiline namespaces http
-io.streams.string http.server sequences splitting accessors ;
+USING: kernel furnace.actions validators tools.test math math.parser
+multiline namespaces http io.streams.string http.server http.server.requests
+sequences splitting accessors ;
 IN: furnace.actions.tests
 
 <action>

--- a/basis/http/http-tests.factor
+++ b/basis/http/http-tests.factor
@@ -1,8 +1,8 @@
 USING: destructors http http.server http.server.requests http.client
-http.client.private tools.test multiline fry io.streams.string io.encodings.utf8
-io.encodings.8-bit io.encodings.binary io.encodings.string io.encodings.ascii
-kernel arrays splitting sequences assocs io.sockets db db.sqlite make
-continuations urls hashtables accessors namespaces xml.data
+http.client.private tools.test multiline fry io.streams.string io.crlf
+io.encodings.utf8 io.encodings.8-bit io.encodings.binary io.encodings.string
+io.encodings.ascii kernel arrays splitting sequences assocs io.sockets db
+db.sqlite make continuations urls hashtables accessors namespaces xml.data
 io.encodings.8-bit.latin1 random combinators.short-circuit ;
 IN: http.tests
 
@@ -24,8 +24,6 @@ IN: http.tests
 [ "localhost" ] [ T{ url { protocol "https" } { host "localhost" } { port 443 } } unparse-host ] unit-test
 [ "localhost:8080" ] [ T{ url { protocol "http" } { host "localhost" } { port 8080 } } unparse-host ] unit-test
 [ "localhost:8443" ] [ T{ url { protocol "https" } { host "localhost" } { port 8443 } } unparse-host ] unit-test
-
-: lf>crlf ( string -- string' ) "\n" split "\r\n" join ;
 
 STRING: read-request-test-1
 POST /bar HTTP/1.1

--- a/basis/http/http-tests.factor
+++ b/basis/http/http-tests.factor
@@ -1,7 +1,7 @@
-USING: destructors http http.server http.client http.client.private tools.test
-multiline fry io.streams.string io.encodings.utf8 io.encodings.8-bit
-io.encodings.binary io.encodings.string io.encodings.ascii kernel
-arrays splitting sequences assocs io.sockets db db.sqlite make
+USING: destructors http http.server http.server.requests http.client
+http.client.private tools.test multiline fry io.streams.string io.encodings.utf8
+io.encodings.8-bit io.encodings.binary io.encodings.string io.encodings.ascii
+kernel arrays splitting sequences assocs io.sockets db db.sqlite make
 continuations urls hashtables accessors namespaces xml.data
 io.encodings.8-bit.latin1 random combinators.short-circuit ;
 IN: http.tests

--- a/basis/http/server/requests/requests-docs.factor
+++ b/basis/http/server/requests/requests-docs.factor
@@ -3,7 +3,13 @@ IN: http.server.requests
 
 HELP: read-request
 { $values { "request" request } }
-{ $description "Reads a HTTP requests from the input stream." } ;
+{ $description "Reads a HTTP requests from the input stream. If the request is not valid or can not be parsed, then a " { $link request-error } " is thrown." } ;
+
+HELP: request-error
+{ $class-description "Thrown by " { $link read-request } " if the HTTP request was invalid." } ;
+
+HELP: bad-request-line
+{ $class-description "Thrown by " { $link read-request } " if the HTTP requests request line could not be parsed." } ;
 
 ARTICLE: "http.server.requests" "Deserializing HTTP requests"
 "The " { $vocab-link "http.server.requests" } " reads requests from the " { $link input-stream } " and creates " { $link request } " tuples." ;

--- a/basis/http/server/requests/requests-docs.factor
+++ b/basis/http/server/requests/requests-docs.factor
@@ -1,0 +1,11 @@
+USING: help.markup help.syntax http io ;
+IN: http.server.requests
+
+HELP: read-request
+{ $values { "request" request } }
+{ $description "Reads a HTTP requests from the input stream." } ;
+
+ARTICLE: "http.server.requests" "Deserializing HTTP requests"
+"The " { $vocab-link "http.server.requests" } " reads requests from the " { $link input-stream } " and creates " { $link request } " tuples." ;
+
+ABOUT: "http.server.requests"

--- a/basis/http/server/requests/requests-tests.factor
+++ b/basis/http/server/requests/requests-tests.factor
@@ -1,0 +1,63 @@
+USING: accessors assocs http http.server.requests io.streams.string kernel
+sequences tools.test urls ;
+IN: http.server.requests.tests
+
+! content-length in combination with POST
+{ "foo=bar" "7" } [
+    {
+        "POST / HTTP/1.1"
+        "connection: close"
+        "host: 127.0.0.1:55532"
+        "user-agent: Factor http.client"
+        "content-length: 7"
+        ""
+        "foo=bar"
+    } "\n" join [ read-request ] with-string-reader
+    [ post-data>> data>> ] [ header>> "content-length" of ] bi
+] unit-test
+
+{ f "0" } [
+    {
+        "POST / HTTP/1.1"
+        "connection: close"
+        "host: 127.0.0.1:55532"
+        "user-agent: Factor http.client"
+        "content-length: 0"
+        ""
+        ""
+    } "\n" join [ read-request ] with-string-reader
+    [ post-data>> data>> ] [ header>> "content-length" of ] bi
+] unit-test
+
+! RFC 2616: Section 4.1
+! In the interest of robustness, servers SHOULD ignore any empty
+! line(s) received where a Request-Line is expected. In other words, if
+! the server is reading the protocol stream at the beginning of a
+! message and receives a CRLF first, it should ignore the CRLF.
+[
+    T{ request
+        { method "GET" }
+        { url URL" /" }
+        { version "1.0" }
+        { header H{ } }
+        { cookies V{ } }
+        { redirects 10 }
+    }
+] [
+    "\r\n\r\n\r\nGET / HTTP/1.0\r\n\r\n"
+    [ read-request ] with-string-reader
+] unit-test
+
+! RFC 2616: Section 19.3
+! The line terminator for message-header fields is the sequence CRLF.
+! However, we recommend that applications, when parsing such headers,
+! recognize a single LF as a line terminator and ignore the leading CR.
+[ t ] [
+    {
+        "GET / HTTP/1.1"
+        "connection: close"
+        "host: 127.0.0.1:55532"
+        "user-agent: Factor http.client"
+    } [ "\n" join ] [ "\r\n" join ] bi
+    [ [ read-request ] with-string-reader ] same?
+] unit-test

--- a/basis/http/server/requests/requests-tests.factor
+++ b/basis/http/server/requests/requests-tests.factor
@@ -1,10 +1,8 @@
 USING: accessors assocs continuations http http.client http.client.private
-http.server http.server.requests io.streams.limited io.streams.string kernel
-math math.parser multiline namespaces peg sequences splitting tools.test urls ;
+http.server http.server.requests io.crlf io.streams.limited io.streams.string
+kernel math math.parser multiline namespaces peg sequences splitting
+tools.test urls ;
 IN: http.server.requests.tests
-
-: normalize-nl ( str -- str' )
-    "\n" "\r\n" replace ;
 
 : request>string ( request -- string )
     [ write-request ] with-string-writer ;
@@ -59,7 +57,7 @@ hello
           "form-data; name=\"text\"; filename=\"upload.txt\"" }
     }
 } [
-    test-multipart/form-data normalize-nl string>request
+    test-multipart/form-data lf>crlf string>request
     post-data>> params>> "text" of [ filename>> ] [ headers>> ] bi
 ] unit-test
 
@@ -142,8 +140,7 @@ hello
         { redirects 10 }
     }
 ] [
-    "\r\n\r\n\r\nGET / HTTP/1.0\r\n\r\n"
-    [ read-request ] with-string-reader
+    "\r\n\r\n\r\nGET / HTTP/1.0\r\n\r\n" [ read-request ] with-string-reader
 ] unit-test
 
 ! RFC 2616: Section 19.3
@@ -157,5 +154,5 @@ hello
         "host: 127.0.0.1:55532"
         "user-agent: Factor http.client"
     } [ "\n" join ] [ "\r\n" join ] bi
-    [ [ read-request ] with-string-reader ] same?
+    [ string>request ] same?
 ] unit-test

--- a/basis/http/server/requests/requests-tests.factor
+++ b/basis/http/server/requests/requests-tests.factor
@@ -1,32 +1,102 @@
-USING: accessors assocs http http.server.requests io.streams.string kernel
-sequences tools.test urls ;
+USING: accessors assocs http http.server http.server.requests
+io.streams.limited io.streams.string kernel multiline namespaces sequences
+splitting tools.test urls ;
 IN: http.server.requests.tests
 
-! content-length in combination with POST
+: normalize-nl ( str -- str' )
+    "\n" "\r\n" replace ;
+
+: string>request ( str -- request )
+    normalize-nl
+    [ request-limit get limited-input read-request ] with-string-reader ;
+
+! POST requests
+STRING: test-post-no-content-type
+POST / HTTP/1.1
+connection: close
+host: 127.0.0.1:55532
+user-agent: Factor http.client
+content-length: 7
+
+foo=bar
+;
 { "foo=bar" "7" } [
-    {
-        "POST / HTTP/1.1"
-        "connection: close"
-        "host: 127.0.0.1:55532"
-        "user-agent: Factor http.client"
-        "content-length: 7"
-        ""
-        "foo=bar"
-    } "\n" join [ read-request ] with-string-reader
+    test-post-no-content-type string>request
     [ post-data>> data>> ] [ header>> "content-length" of ] bi
 ] unit-test
 
+STRING: test-post-0-content-length
+POST / HTTP/1.1
+connection: close
+host: 127.0.0.1:55532
+user-agent: Factor http.client
+content-length: 0
+
+
+;
 { f "0" } [
-    {
-        "POST / HTTP/1.1"
-        "connection: close"
-        "host: 127.0.0.1:55532"
-        "user-agent: Factor http.client"
-        "content-length: 0"
-        ""
-        ""
-    } "\n" join [ read-request ] with-string-reader
+    test-post-0-content-length string>request
     [ post-data>> data>> ] [ header>> "content-length" of ] bi
+] unit-test
+
+! Should work no problem.
+STRING: test-post-wrong-content-length
+POST / HTTP/1.1
+connection: close
+host: 127.0.0.1:55532
+user-agent: Factor http.client
+Content-Type: application/x-www-form-urlencoded; charset=utf-8
+content-length: 190
+
+foo=bar
+;
+{ H{ { "foo" "bar" } } } [
+    test-post-wrong-content-length string>request post-data>> params>>
+] unit-test
+
+STRING: test-post-urlencoded
+POST / HTTP/1.1
+Accept: */*
+Accept-Encoding: gzip, deflate
+Connection: keep-alive
+Content-Length: 15
+Content-Type: application/x-www-form-urlencoded; charset=utf-8
+Host: news.ycombinator.com
+User-Agent: HTTPie/0.9.0-dev
+
+name=John+Smith
+;
+{ H{ { "name" "John Smith" } } } [
+    test-post-urlencoded string>request post-data>> params>>
+] unit-test
+
+! multipart/form-data
+STRING: test-multipart/form-data
+POST / HTTP/1.1
+Accept: */*
+Accept-Encoding: gzip, deflate
+Connection: keep-alive
+Content-Length: 151
+Content-Type: multipart/form-data; boundary=768de80194d942619886d23f1337aa15
+Host: localhost:8000
+User-Agent: HTTPie/0.9.0-dev
+
+--768de80194d942619886d23f1337aa15
+Content-Disposition: form-data; name="text"; filename="upload.txt"
+
+hello
+--768de80194d942619886d23f1337aa15--
+
+;
+{
+    "upload.txt"
+    H{
+        { "content-disposition"
+          "form-data; name=\"text\"; filename=\"upload.txt\"" }
+    }
+} [
+    test-multipart/form-data string>request post-data>> params>> "text" of
+    [ filename>> ] [ headers>> ] bi
 ] unit-test
 
 ! RFC 2616: Section 4.1

--- a/basis/http/server/requests/requests-tests.factor
+++ b/basis/http/server/requests/requests-tests.factor
@@ -1,6 +1,6 @@
 USING: accessors assocs continuations http http.client http.client.private
 http.server http.server.requests io.streams.limited io.streams.string kernel
-multiline namespaces peg sequences splitting tools.test urls ;
+math math.parser multiline namespaces peg sequences splitting tools.test urls ;
 IN: http.server.requests.tests
 
 : normalize-nl ( str -- str' )
@@ -116,6 +116,16 @@ hello
     [ invalid-content-length? ]
     [ content-length>> -1234 = ] bi and
 ] must-fail-with
+
+! And too big
+[
+    { { "foo" "bar" } } "localhost" <post-request> request>string
+    "7" upload-limit get 1 + number>string replace string>request
+] [
+    [ invalid-content-length? ]
+    [ content-length>> upload-limit get 1 + = ] bi and
+] must-fail-with
+
 
 ! RFC 2616: Section 4.1
 ! In the interest of robustness, servers SHOULD ignore any empty

--- a/basis/http/server/requests/requests.factor
+++ b/basis/http/server/requests/requests.factor
@@ -48,7 +48,9 @@ upload-limit [ 200,000,000 ] initialize
 : parse-content-length-safe ( request -- content-length )
     "content-length" header [
         dup string>number [
-            nip dup 0 >= [ invalid-content-length ] unless
+            nip dup 0 upload-limit get between? [
+                invalid-content-length
+            ] unless
         ] [ invalid-content-length ] if*
     ] [ content-length-missing ] if* ;
 

--- a/basis/http/server/requests/requests.factor
+++ b/basis/http/server/requests/requests.factor
@@ -1,0 +1,66 @@
+USING: accessors combinators http http.parsers io io.crlf io.encodings
+io.encodings.binary io.streams.limited kernel math.order math.parser
+namespaces sequences splitting urls urls.encoding ;
+FROM: mime.multipart => parse-multipart ;
+IN: http.server.requests
+
+ERROR: no-boundary ;
+
+: check-absolute ( url -- url )
+    dup path>> "/" head? [ "Bad request: URL" throw ] unless ; inline
+
+: read-request-line ( request -- request )
+    read-?crlf [ dup "" = ] [ drop read-?crlf ] while
+    parse-request-line first3
+    [ >>method ] [ >url check-absolute >>url ] [ >>version ] tri* ;
+
+: read-request-header ( request -- request )
+    read-header >>header ;
+
+SYMBOL: upload-limit
+
+upload-limit [ 200,000,000 ] initialize
+
+: parse-multipart-form-data ( string -- separator )
+    ";" split1 nip
+    "=" split1 nip [ no-boundary ] unless* ;
+
+: read-multipart-data ( request -- mime-parts )
+    [ "content-type" header ]
+    [ "content-length" header string>number ] bi
+    unlimited-input
+    upload-limit get [ min ] when* limited-input
+    binary decode-input
+    parse-multipart-form-data parse-multipart ;
+
+: read-content ( request -- bytes )
+    "content-length" header string>number read ;
+
+: parse-content ( request content-type -- post-data )
+    [ <post-data> swap ] keep {
+        { "multipart/form-data" [ read-multipart-data >>params ] }
+        { "application/x-www-form-urlencoded" [ read-content query>assoc >>params ] }
+        [ drop read-content >>data ]
+    } case ;
+
+: read-post-data ( request -- request )
+    dup method>> "POST" = [
+        dup dup "content-type" header
+        ";" split1 drop parse-content >>post-data
+    ] when ;
+
+: extract-host ( request -- request )
+    [ ] [ url>> ] [ "host" header parse-host ] tri
+    [ >>host ] [ >>port ] bi*
+    drop ;
+
+: extract-cookies ( request -- request )
+    dup "cookie" header [ parse-cookie >>cookies ] when* ;
+
+: read-request ( -- request )
+    <request>
+    read-request-line
+    read-request-header
+    read-post-data
+    extract-host
+    extract-cookies ;

--- a/basis/http/server/server-docs.factor
+++ b/basis/http/server/server-docs.factor
@@ -1,5 +1,5 @@
-USING: assocs help.markup help.syntax http io.servers kernel
-math strings urls vocabs.refresh ;
+USING: assocs continuations help.markup help.syntax http http.server.requests
+io.servers kernel math strings urls vocabs.refresh ;
 IN: http.server
 
 HELP: trivial-responder
@@ -37,6 +37,10 @@ HELP: post-request?
 
 HELP: responder-nesting
 { $description "A sequence of " { $snippet "{ path responder }" } " pairs." } ;
+
+HELP: handle-client-error
+{ $values { "error" error } }
+{ $description "Handles an error that may have occurred during the processing of a request. The rules are: 1) if the error is caused by an empty request line, it is silenced because it is a redundant dummy request issued by certain browsers. 2) if the error is a " { $link request-error } " then it is logged and the client is served a 400 Bad Request. 3) all other errors are thrown upwards." } ;
 
 HELP: http-server
 { $class-description "The class of HTTP servers. New instances are created by calling " { $link <http-server> } "." } ;

--- a/basis/http/server/server-tests.factor
+++ b/basis/http/server/server-tests.factor
@@ -1,4 +1,4 @@
-USING: accessors continuations http http.server
+USING: accessors assocs continuations http http.server
 io.encodings.utf8 io.encodings.binary io.streams.string kernel
 math peg sequences tools.test urls ;
 IN: http.server.tests
@@ -27,40 +27,6 @@ IN: http.server.tests
 [ "application/octet-stream" ] [
     <response>
     unparse-content-type
-] unit-test
-
-
-! RFC 2616: Section 19.3
-! The line terminator for message-header fields is the sequence CRLF.
-! However, we recommend that applications, when parsing such headers,
-! recognize a single LF as a line terminator and ignore the leading CR.
-[ t ] [
-    {
-        "GET / HTTP/1.1"
-        "connection: close"
-        "host: 127.0.0.1:55532"
-        "user-agent: Factor http.client"
-    } [ "\n" join ] [ "\r\n" join ] bi
-    [ [ read-request ] with-string-reader ] same?
-] unit-test
-
-! RFC 2616: Section 4.1
-! In the interest of robustness, servers SHOULD ignore any empty
-! line(s) received where a Request-Line is expected. In other words, if
-! the server is reading the protocol stream at the beginning of a
-! message and receives a CRLF first, it should ignore the CRLF.
-[
-    T{ request
-        { method "GET" }
-        { url URL" /" }
-        { version "1.0" }
-        { header H{ } }
-        { cookies V{ } }
-        { redirects 10 }
-    }
-] [
-    "\r\n\r\n\r\nGET / HTTP/1.0\r\n\r\n"
-    [ read-request ] with-string-reader
 ] unit-test
 
 ! Don't rethrow parse-errors with an empty request string. They are

--- a/basis/http/server/server-tests.factor
+++ b/basis/http/server/server-tests.factor
@@ -1,6 +1,6 @@
 USING: accessors assocs continuations http http.server
-io.encodings.utf8 io.encodings.binary io.streams.string kernel
-math peg sequences tools.test urls ;
+http.server.requests io.encodings.utf8 io.encodings.binary io.streams.string
+kernel math peg sequences tools.test urls ;
 IN: http.server.tests
 
 [ t ] [ [ \ + first ] [ <500> ] recover response? ] unit-test
@@ -32,7 +32,9 @@ IN: http.server.tests
 ! Don't rethrow parse-errors with an empty request string. They are
 ! expected from certain browsers when the server serves a certificate
 ! that the browser can't verify.
-{ } [ 0 "" f <parse-error> handle-client-error ] unit-test
+{ } [
+    0 "" f <parse-error> \ bad-request-line boa handle-client-error
+] unit-test
 
 [
     0 "not empty" f <parse-error> handle-client-error

--- a/basis/http/server/server.factor
+++ b/basis/http/server/server.factor
@@ -225,7 +225,8 @@ SYMBOL: request-limit
 request-limit [ 64 1024 * ] initialize
 
 : handle-client-error ( error -- )
-    dup { [ parse-error? ] [ got>> empty? ] } 1&& [ drop ] [ rethrow ] if ;
+    dup { [ bad-request-line? ] [ parse-error>> got>> empty? ] } 1&&
+    [ drop ] [ rethrow ] if ;
 
 M: http-server handle-client*
     drop [

--- a/basis/http/server/server.factor
+++ b/basis/http/server/server.factor
@@ -2,8 +2,8 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: kernel accessors sequences arrays namespaces splitting
 vocabs.loader destructors assocs debugger continuations
-combinators combinators.short-circuit vocabs.refresh tools.time math
-present vectors hashtables
+combinators combinators.short-circuit vocabs.refresh
+tools.time math present vectors hashtables
 io
 io.sockets
 io.sockets.secure
@@ -29,7 +29,6 @@ html.streams
 html
 mime.types
 math.order
-peg
 xml.writer
 vocabs ;
 IN: http.server
@@ -224,9 +223,13 @@ SYMBOL: request-limit
 
 request-limit [ 64 1024 * ] initialize
 
+LOG: httpd-bad-request NOTICE
+
 : handle-client-error ( error -- )
-    dup { [ bad-request-line? ] [ parse-error>> got>> empty? ] } 1&&
-    [ drop ] [ rethrow ] if ;
+    dup request-error? [
+        dup { [ bad-request-line? ] [ parse-error>> got>> empty? ] } 1&&
+        [ drop ] [ httpd-bad-request <400> write-response ] if
+    ] [ rethrow ] if ;
 
 M: http-server handle-client*
     drop [

--- a/basis/io/crlf/crlf-tests.factor
+++ b/basis/io/crlf/crlf-tests.factor
@@ -11,3 +11,6 @@ USING: io.crlf tools.test io.streams.string io ;
 [ f ] [ "" [ read-?crlf ] with-string-reader ] unit-test
 [ "" ] [ "\n" [ read-?crlf ] with-string-reader ] unit-test
 [ "foo" ] [ "foo\n" [ read-?crlf ] with-string-reader ] unit-test
+
+[ "foo\nbar" ] [ "foo\n\rbar" crlf>lf ] unit-test
+[ "foo\r\nbar" ] [ "foo\nbar" lf>crlf ] unit-test

--- a/basis/io/crlf/crlf.factor
+++ b/basis/io/crlf/crlf.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2009 Daniel Ehrenberg, Slava Pestov
 ! See http://factorcode.org/license.txt for BSD license.
-USING: io kernel sequences ;
+USING: io kernel sequences splitting ;
 IN: io.crlf
 
 : crlf ( -- )
@@ -13,3 +13,9 @@ IN: io.crlf
 : read-?crlf ( -- seq )
     "\r\n" read-until
     [ CHAR: \r = [ read1 CHAR: \n assert= ] when ] [ f like ] if* ;
+
+: crlf>lf ( str -- str' )
+    CHAR: \r swap remove ;
+
+: lf>crlf ( str -- str' )
+    "\n" split "\r\n" join ;

--- a/basis/mime/multipart/multipart-tests.factor
+++ b/basis/mime/multipart/multipart-tests.factor
@@ -4,35 +4,58 @@ USING: accessors assocs continuations fry http.server io
 io.encodings.ascii io.files io.files.unique
 io.servers io.streams.duplex io.streams.string
 kernel math.ranges mime.multipart multiline namespaces random
-sequences strings threads tools.test ;
+sequences sorting strings threads tools.test ;
 IN: mime.multipart.tests
 
-: upload-separator ( -- seq )
-   "----WebKitFormBoundary6odjpVPXIighAE2L" ;
+CONSTANT: separator1 "----WebKitFormBoundary6odjpVPXIighAE2L"
 
-: upload ( -- seq )
-   "------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"file1\"; filename=\"up.txt\"\r\nContent-Type: text/plain\r\n\r\nuploaded!\n\r\n------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"file2\"; filename=\"\"\r\n\r\n\r\n------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"file3\"; filename=\"\"\r\n\r\n\r\n------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"text1\"\r\n\r\nlol\r\n------WebKitFormBoundary6odjpVPXIighAE2L--\r\n" ;
+CONSTANT: upload1 "------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"file1\"; filename=\"up.txt\"\r\nContent-Type: text/plain\r\n\r\nuploaded!\n\r\n------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"file2\"; filename=\"\"\r\n\r\n\r\n------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"file3\"; filename=\"\"\r\n\r\n\r\n------WebKitFormBoundary6odjpVPXIighAE2L\r\nContent-Disposition: form-data; name=\"text1\"\r\n\r\nlol\r\n------WebKitFormBoundary6odjpVPXIighAE2L--\r\n"
 
 : mime-test-stream ( -- stream )
-   upload
+   upload1
    "mime" "test" make-unique-file ascii
    [ set-file-contents ] [ <file-reader> ] 2bi ;
 
 [ ] [ mime-test-stream [ ] with-input-stream ] unit-test
 
 [ t ] [
-    mime-test-stream [ upload-separator parse-multipart ] with-input-stream
+    mime-test-stream [ separator1 parse-multipart ] with-input-stream
     "file1" swap key?
 ] unit-test
 
 [ t ] [
-    mime-test-stream [ upload-separator parse-multipart ] with-input-stream
+    mime-test-stream [ separator1 parse-multipart ] with-input-stream
     "file1" swap key?
 ] unit-test
 
 [ t ] [
-    mime-test-stream [ upload-separator parse-multipart ] with-input-stream
+    mime-test-stream [ separator1 parse-multipart ] with-input-stream
     "file1" of filename>> "up.txt" =
+] unit-test
+
+CONSTANT: separator2 "768de80194d942619886d23f1337aa15"
+CONSTANT: upload2 "--768de80194d942619886d23f1337aa15\r\nContent-Disposition: form-data; name=\"text\"; filename=\"upload.txt\"\r\nContent-Type: text/plain\r\n\r\nhello\r\n--768de80194d942619886d23f1337aa15--\r\n"
+
+[
+    "upload.txt"
+    H{
+        { "content-disposition"
+          "form-data; name=\"text\"; filename=\"upload.txt\"" }
+        { "content-type" "text/plain" }
+    }
+] [
+    upload2 [ separator2 parse-multipart ] with-string-reader
+    "text" of [ filename>> ] [ headers>> ] bi
+] unit-test
+
+CONSTANT: separator3 "3f116598c7f0431b9f98148ed235c822"
+CONSTANT: upload3 "--3f116598c7f0431b9f98148ed235c822\r\nContent-Disposition: form-data; name=\"text\"; filename=\"upload.txt\"\r\n\r\nhello\r\n--3f116598c7f0431b9f98148ed235c822\r\nContent-Disposition: form-data; name=\"text2\"; filename=\"upload.txt\"\r\n\r\nhello\r\n--3f116598c7f0431b9f98148ed235c822--\r\n"
+
+[
+    { "text" "text2" }
+] [
+    upload3 [ separator3 parse-multipart ] with-string-reader
+    keys natural-sort
 ] unit-test
 
 SYMBOL: mime-test-server

--- a/basis/mime/multipart/multipart.factor
+++ b/basis/mime/multipart/multipart.factor
@@ -42,9 +42,6 @@ ERROR: end-of-stream multipart ;
     [ '[ _ B{ } append-as ] change-bytes ]
     [ t >>end-of-stream? ] if* ;
 
-: maybe-fill-bytes ( multipart -- multipart )
-    dup bytes>> length 256 < [ fill-bytes ] when ;
-
 : split-bytes ( bytes separator -- leftover-bytes safe-to-dump )
     dupd [ length ] bi@ 1 - - short cut-slice swap ;
 
@@ -66,7 +63,6 @@ ERROR: end-of-stream multipart ;
     [ dump-until-separator ] with-string-writer ;
 
 : read-header ( multipart -- multipart )
-    maybe-fill-bytes
     dup bytes>> "--\r\n" sequence= [
         t >>end-of-stream?
     ] [

--- a/basis/ui/backend/windows/windows.factor
+++ b/basis/ui/backend/windows/windows.factor
@@ -10,7 +10,7 @@ windows.kernel32 windows.gdi32 windows.user32 windows.opengl32
 windows.messages windows.types windows.offscreen windows threads
 libc combinators fry combinators.short-circuit continuations
 command-line shuffle opengl ui.render math.bitwise locals
-accessors math.rectangles math.order calendar ascii sets
+accessors math.rectangles math.order calendar ascii sets io.crlf
 io.encodings.utf16n windows.errors literals ui.pixel-formats
 ui.pixel-formats.private memoize classes colors
 specialized-arrays classes.struct ;
@@ -172,12 +172,6 @@ PRIVATE>
 : GET_APPCOMMAND_LPARAM ( lParam -- appCommand )
     hi-word FAPPCOMMAND_MASK lo-word bitnot bitand ; inline
 
-: crlf>lf ( str -- str' )
-    CHAR: \r swap remove ;
-
-: lf>crlf ( str -- str' )
-    [ [ dup CHAR: \n = [ CHAR: \r , ] when , ] each ] "" make ;
-
 : enum-clipboard ( -- seq )
     0
     [ EnumClipboardFormats win32-error dup dup 0 > ]
@@ -209,7 +203,7 @@ PRIVATE>
         EmptyClipboard win32-error=0/f
         GMEM_MOVEABLE over length 1 + GlobalAlloc
             dup win32-error=0/f
-    
+
         dup GlobalLock dup win32-error=0/f
         rot binary-object memcpy
         dup GlobalUnlock win32-error=0/f
@@ -506,7 +500,7 @@ SYMBOL: nc-buttons
         { APPCOMMAND_BROWSER_FORWARD [ pick window right-action send-action ] }
         [ drop ]
     } case 3drop ;
-    
+
 : handle-wm-buttondown ( hWnd uMsg wParam lParam -- )
     [
         over set-capture
@@ -542,7 +536,7 @@ SYMBOL: nc-buttons
     4drop release-capture ;
 
 : handle-wm-mouseleave ( hWnd uMsg wParam lParam -- )
-    #! message sent if mouse leaves main application 
+    #! message sent if mouse leaves main application
     4drop forget-rollover ;
 
 : system-background-color ( -- color )
@@ -868,4 +862,3 @@ M: windows-ui-backend ui-backend-available?
     t ;
 
 windows-ui-backend ui-backend set-global
-


### PR DESCRIPTION
So I was trying to get the http server to server a webapp for me and then I found that it is childs play to break it. By forging malicious requests you can get the server to crash and/or hang. E.g factorcode.org could probably easily be crashed if it is not behind a web proxy.

To fix that, I made a new vocab http.server.requests with all the request parsing moved into there. I've tried to make it safer, eg it shouldn't crash if a `string>number` call fails. The idea is that if someone makes a naughty request, that vocab will throw a `request-error` and the server will log and respond with 400 Bad Request which is consistent with what other web servers do. 

Other errors will still be bubbled up like they are now, which I think is nice because then if the web server logs `ERROR`, you know there is a bug in the code, but if it logs `NOTICE httpd-bad-request:` you know the client sent a bogus request.