### PR TITLE
Fix 1187 attempt3

### DIFF
--- a/basis/compiler/cfg/finalization/finalization.factor
+++ b/basis/compiler/cfg/finalization/finalization.factor
@@ -2,15 +2,13 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: compiler.cfg.build-stack-frame compiler.cfg.gc-checks
 compiler.cfg.linear-scan compiler.cfg.representations
-compiler.cfg.save-contexts compiler.cfg.scheduling
-compiler.cfg.ssa.destruction compiler.cfg.stacks.vacant
-compiler.cfg.utilities compiler.cfg.write-barrier ;
+compiler.cfg.save-contexts compiler.cfg.ssa.destruction
+compiler.cfg.stacks.vacant compiler.cfg.utilities compiler.cfg.write-barrier ;
 IN: compiler.cfg.finalization
 
 : finalize-cfg ( cfg -- )
     {
         select-representations
-        schedule-instructions
         insert-gc-checks
         eliminate-write-barriers
         compute-vacant-sets

--- a/basis/compiler/cfg/finalization/finalization.factor
+++ b/basis/compiler/cfg/finalization/finalization.factor
@@ -3,7 +3,8 @@
 USING: compiler.cfg.build-stack-frame compiler.cfg.gc-checks
 compiler.cfg.linear-scan compiler.cfg.representations
 compiler.cfg.save-contexts compiler.cfg.ssa.destruction
-compiler.cfg.stacks.vacant compiler.cfg.utilities compiler.cfg.write-barrier ;
+compiler.cfg.stacks.clearing compiler.cfg.stacks.vacant compiler.cfg.utilities
+compiler.cfg.write-barrier ;
 IN: compiler.cfg.finalization
 
 : finalize-cfg ( cfg -- )
@@ -11,7 +12,8 @@ IN: compiler.cfg.finalization
         select-representations
         insert-gc-checks
         eliminate-write-barriers
-        compute-vacant-sets
+        clear-uninitialized
+        fill-gc-maps
         insert-save-contexts
         destruct-ssa
         linear-scan

--- a/basis/compiler/cfg/optimizer/optimizer.factor
+++ b/basis/compiler/cfg/optimizer/optimizer.factor
@@ -6,7 +6,6 @@ compiler.cfg.block-joining
 compiler.cfg.branch-splitting
 compiler.cfg.copy-prop
 compiler.cfg.dce
-compiler.cfg.height
 compiler.cfg.ssa.construction
 compiler.cfg.tco
 compiler.cfg.useless-conditionals
@@ -21,7 +20,6 @@ IN: compiler.cfg.optimizer
         delete-useless-conditionals
         split-branches
         join-blocks
-        normalize-height
         construct-ssa
         alias-analysis
         value-numbering

--- a/basis/compiler/cfg/stacks/clearing/clearing-docs.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing-docs.factor
@@ -1,0 +1,35 @@
+USING: compiler.cfg compiler.cfg.instructions help.markup help.syntax sequences strings ;
+IN: compiler.cfg.stacks.clearing
+
+ARTICLE: "compiler.cfg.stacks.clearing" "Uninitialized stack location clearing"
+"A compiler pass that inserts " { $link ##replace-imm } " instructions front of unsafe " { $link ##peek } " instructions in the " { $link cfg } ". Consider the following sequence of instructions."
+{ $code
+  "##inc-d 2"
+  "##peek RCX D 2"
+}
+"The ##peek can cause a stack underflow and then there will be two uninitialized locations on the data stack that can't be traced. To counteract that, this pass modifies the instruction sequence so that it becomes:"
+{ $code
+  "##inc-d 2"
+  "##replace-imm 17 D 0"
+  "##replace-imm 17 D 1"
+  "##peek RCX D 2"
+} ;
+
+HELP: dangerous-insn?
+{ $values { "state" "a stack state" } { "insn" insn } }
+{ $description "Checks if the instruction is dangerous (can cause a stack underflow). " }
+{ $examples
+  { $example
+    "USING: compiler.cfg.instructions compiler.cfg.registers prettyprint ;"
+    "{ { 0 { } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-insn? ."
+    "t"
+  }
+  { $example
+    "USING: compiler.cfg.instructions compiler.cfg.registers prettyprint ;"
+    "{ { 0 { } } { 2 { 0 1 } } } T{ ##peek { loc R 0 } } dangerous-insn? ."
+    "f"
+  }
+} ;
+
+
+ABOUT: "compiler.cfg.stacks.clearing"

--- a/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
@@ -1,5 +1,6 @@
-USING: compiler.cfg.instructions compiler.cfg.registers
-compiler.cfg.stacks.clearing tools.test ;
+USING: compiler.cfg.instructions compiler.cfg.linearization
+compiler.cfg.registers compiler.cfg.stacks.clearing compiler.cfg.utilities
+kernel tools.test ;
 IN: compiler.cfg.stacks.clearing.tests
 
 { { } } [
@@ -19,4 +20,16 @@ IN: compiler.cfg.stacks.clearing.tests
     }
 } [
     { { 2 { } } { 0 { } } } state>replaces
+] unit-test
+
+{
+    V{
+        T{ ##inc-d { n 2 } { insn# 0 } }
+        T{ ##replace-imm { src 17 } { loc T{ ds-loc } } }
+        T{ ##replace-imm { src 17 } { loc T{ ds-loc { n 1 } } } }
+        T{ ##peek { loc T{ ds-loc { n 2 } } } { insn# 1 } }
+    }
+} [
+    { T{ ##inc-d f 2 } T{ ##peek f f D 2 } } insns>cfg
+    dup clear-uninitialized cfg>insns
 ] unit-test

--- a/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
@@ -6,9 +6,10 @@ IN: compiler.cfg.stacks.clearing.tests
     { { 0 { } } { 0 { } } } state>replaces
 ] unit-test
 
-{ t f } [
+{ t f f } [
     { { 0 { } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-insn?
-    { { 0 { } } { 0 { } } } T{ ##peek { loc D -1 } } dangerous-insn?
+    { { 1 { 0 } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-insn?
+    { { 0 { -1 } } { 0 { } } } T{ ##peek { loc D -1 } } dangerous-insn?
 ] unit-test
 
 {

--- a/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
@@ -1,0 +1,21 @@
+USING: compiler.cfg.instructions compiler.cfg.registers
+compiler.cfg.stacks.clearing tools.test ;
+IN: compiler.cfg.stacks.clearing.tests
+
+{ { } } [
+    { { 0 { } } { 0 { } } } state>replaces
+] unit-test
+
+{ t f } [
+    { { 0 { } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-insn?
+    { { 0 { } } { 0 { } } } T{ ##peek { loc D -1 } } dangerous-insn?
+] unit-test
+
+{
+    {
+        T{ ##replace-imm { src 17 } { loc D 0 } }
+        T{ ##replace-imm { src 17 } { loc D 1 } }
+    }
+} [
+    { { 2 { } } { 0 { } } } state>replaces
+] unit-test

--- a/basis/compiler/cfg/stacks/clearing/clearing.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing.factor
@@ -12,7 +12,7 @@ IN: compiler.cfg.stacks.clearing
     { [ nip ##peek? ] [ underflowable-peek? ] } 2&& ;
 
 : clearing-replaces ( assoc insn -- insns' )
-    [ of ] keep 2dup dangerous-insn? [
+    [ insn#>> of ] keep 2dup dangerous-insn? [
         drop state>replaces
     ] [ 2drop { } ] if ;
 

--- a/basis/compiler/cfg/stacks/clearing/clearing.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing.factor
@@ -1,0 +1,25 @@
+USING: accessors arrays assocs combinators.short-circuit
+compiler.cfg.instructions compiler.cfg.registers compiler.cfg.rpo
+compiler.cfg.stacks.map kernel math sequences ;
+IN: compiler.cfg.stacks.clearing
+
+: state>replaces ( state -- replaces )
+    state>vacancies first2
+    [ [ <ds-loc> ] map ] [ [ <rs-loc> ] map ] bi* append
+    [ 17 swap f ##replace-imm boa ] map ;
+
+: dangerous-insn? ( state insn -- ? )
+    { [ nip ##peek? ] [ dangerous-peek? ] } 2&& ;
+
+: clearing-replaces ( assoc insn -- insns' )
+    [ of ] keep 2dup dangerous-insn? [
+        drop state>replaces
+    ] [ 2drop { } ] if ;
+
+: visit-insns ( assoc insns -- insns' )
+    [ [ clearing-replaces ] keep suffix ] with map V{ } concat-as ;
+
+: clear-uninitialized ( cfg -- )
+    [ trace-stack-state ] keep [
+        [ visit-insns ] change-instructions drop
+    ] with each-basic-block ;

--- a/basis/compiler/cfg/stacks/clearing/clearing.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing.factor
@@ -4,12 +4,12 @@ compiler.cfg.stacks.map kernel math sequences ;
 IN: compiler.cfg.stacks.clearing
 
 : state>replaces ( state -- replaces )
-    state>vacancies first2
+    [ stack>vacant ] map first2
     [ [ <ds-loc> ] map ] [ [ <rs-loc> ] map ] bi* append
     [ 17 swap f ##replace-imm boa ] map ;
 
 : dangerous-insn? ( state insn -- ? )
-    { [ nip ##peek? ] [ dangerous-peek? ] } 2&& ;
+    { [ nip ##peek? ] [ underflowable-peek? ] } 2&& ;
 
 : clearing-replaces ( assoc insn -- insns' )
     [ of ] keep 2dup dangerous-insn? [

--- a/basis/compiler/cfg/stacks/map/map-tests.factor
+++ b/basis/compiler/cfg/stacks/map/map-tests.factor
@@ -65,15 +65,15 @@ IN: compiler.cfg.stacks.map.tests
 {
     H{
         {
-            T{ ##inc-d { n 2 } }
+            0
             { { 0 { } } { 0 { } } }
         }
         {
-            T{ ##peek { loc D 2 } }
+            1
             { { 2 { } } { 0 { } } }
         }
         {
-            T{ ##inc-d { n 0 } }
+            2
             { { 2 { 0 1 2 } } { 0 { } } }
         }
     }
@@ -86,31 +86,33 @@ IN: compiler.cfg.stacks.map.tests
 ] unit-test
 
 ! Runs the analysis and check what the resulting stack map becomes.
-
-: output-stack-map ( cfg -- map )
-    H{ } clone stack-record set
-    map-analysis run-dataflow-analysis
-    nip [ [ number>> ] dip ] assoc-map >alist natural-sort last second ;
+: following-stack-state ( insns -- state )
+    T{ ##branch } suffix insns>cfg trace-stack-state
+    >alist [ first ] sort-with last second ;
 
 ! Initially both the d and r stacks are empty.
 {
     { { 0 { } } { 0 { } } }
-} [ V{ } insns>cfg output-stack-map ] unit-test
+} [ V{ } following-stack-state ] unit-test
 
 {
-    { { 0 { } } { 0 { } } }
+    H{
+        { 0 { { 0 { } } { 0 { } } } }
+        { 1 { { 0 { } } { 0 { } } } }
+        { 2 { { 0 { } } { 0 { } } } }
+    }
 } [
     V{ T{ ##safepoint } T{ ##prologue } T{ ##branch } }
-    insns>cfg output-stack-map
+    insns>cfg trace-stack-state
 ] unit-test
 
 {
     { { 1 { } } { 0 { } } }
-} [ V{ T{ ##inc-d f 1 } } insns>cfg output-stack-map ] unit-test
+} [ V{ T{ ##inc-d f 1 } } following-stack-state ] unit-test
 
 {
     { { 0 { } } { 1 { } } }
-} [ V{ T{ ##inc-r f 1 } } insns>cfg output-stack-map ] unit-test
+} [ V{ T{ ##inc-r f 1 } } following-stack-state ] unit-test
 
 ! Here the peek refers to a parameter of the word.
 {
@@ -118,27 +120,39 @@ IN: compiler.cfg.stacks.map.tests
 } [
     V{
         T{ ##peek { loc D 25 } }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] unit-test
 
 ! The peek "causes" the vacant locations to become populated.
 {
-    { { 3 { 0 1 2 3 } } { 0 { } } }
+    H{
+        { 0 { { 0 { } } { 0 { } } } }
+        { 1 { { 3 { } } { 0 { } } } }
+        { 2 { { 3 { 0 1 2 3 } } { 0 { } } } }
+    }
 } [
     V{
         T{ ##inc-d f 3 }
         T{ ##peek { loc D 3 } }
-    } insns>cfg output-stack-map
+        T{ ##branch }
+    }
+    insns>cfg trace-stack-state
 ] unit-test
 
 ! Replace -1 then peek is ok.
 {
-    { { 0 { -1 } } { 0 { } } }
+    H{
+        { 0 { { 0 { } } { 0 { } } } }
+        { 1 { { 0 { -1 } } { 0 { } } } }
+        { 2 { { 0 { -1 } } { 0 { } } } }
+    }
 } [
     V{
         T{ ##replace { src 10 } { loc D -1 } }
         T{ ##peek { loc D -1 } }
-    } insns>cfg output-stack-map
+        T{ ##branch }
+    }
+    insns>cfg trace-stack-state
 ] unit-test
 
 ! Should be ok because the value was at 0 when the gc ran.
@@ -150,7 +164,7 @@ IN: compiler.cfg.stacks.map.tests
         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
         T{ ##inc-d f -1 }
         T{ ##peek { loc D -1 } }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] unit-test
 
 {
@@ -160,7 +174,7 @@ IN: compiler.cfg.stacks.map.tests
         T{ ##replace { src 10 } { loc D 0 } }
         T{ ##replace { src 10 } { loc D 1 } }
         T{ ##replace { src 10 } { loc D 2 } }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] unit-test
 
 {
@@ -170,7 +184,7 @@ IN: compiler.cfg.stacks.map.tests
         T{ ##replace { src 10 } { loc D 0 } }
         T{ ##inc-d f 1 }
         T{ ##replace { src 10 } { loc D 0 } }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] unit-test
 
 {
@@ -181,7 +195,7 @@ IN: compiler.cfg.stacks.map.tests
         T{ ##inc-d f 1 }
         T{ ##replace { src 10 } { loc D 0 } }
         T{ ##inc-d f -1 }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] unit-test
 
 {
@@ -191,7 +205,7 @@ IN: compiler.cfg.stacks.map.tests
         T{ ##inc-d f 1 }
         T{ ##replace { src 10 } { loc D 0 } }
         T{ ##inc-d f -1 }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] unit-test
 
 ! ##call clears the overinitialized slots.
@@ -202,7 +216,7 @@ IN: compiler.cfg.stacks.map.tests
         T{ ##replace { src 10 } { loc D 0 } }
         T{ ##inc-d f -1 }
         T{ ##call }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] unit-test
 
 ! Should not be ok because the value wasn't initialized when gc ran.
@@ -211,21 +225,21 @@ IN: compiler.cfg.stacks.map.tests
         T{ ##inc-d f 1 }
         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
         T{ ##peek { loc D 0 } }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] [ vacant-peek? ] must-fail-with
 
 [
     V{
         T{ ##inc-d f 1 }
         T{ ##peek { loc D 0 } }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] [ vacant-peek? ] must-fail-with
 
 [
     V{
         T{ ##inc-r f 1 }
         T{ ##peek { loc R 0 } }
-    } insns>cfg output-stack-map
+    } following-stack-state
 ] [ vacant-peek? ] must-fail-with
 
 : cfg1 ( -- cfg )
@@ -240,8 +254,13 @@ IN: compiler.cfg.stacks.map.tests
     1vector >>successors block>cfg ;
 
 {
-    { { 0 { -1 } } { 0 { } } }
-} [ cfg1 output-stack-map ] unit-test
+    H{
+        { 0 { { 0 { } } { 0 { } } } }
+        { 1 { { 1 { } } { 0 { } } } }
+        { 2 { { 1 { 0 } } { 0 { } } } }
+        { 3 { { 1 { 0 } } { 0 { } } } }
+    }
+} [ cfg1 trace-stack-state ] unit-test
 
 ! Same cfg structure as the bug1021:run-test word but with
 ! non-datastack instructions mostly omitted.
@@ -291,6 +310,32 @@ IN: compiler.cfg.stacks.map.tests
     } [ over insns>block ] assoc-map dup
     { { 0 1 } { 1 2 } { 2 3 } { 3 8 } { 8 10 } } make-edges 0 of block>cfg ;
 
-{ { 4 { 3 2 1 -3 0 -2 -1 } } } [
-    bug1021-cfg output-stack-map first
+{
+    H{
+        { 0 { { 0 { } } { 0 { } } } }
+        { 1 { { 0 { } } { 0 { } } } }
+        { 2 { { 0 { } } { 0 { } } } }
+        { 3 { { 0 { } } { 0 { } } } }
+        { 4 { { 2 { } } { 0 { } } } }
+        { 5 { { 2 { 1 } } { 0 { } } } }
+        { 6 { { 2 { 1 0 } } { 0 { } } } }
+        { 7 { { 2 { 1 0 } } { 0 { } } } }
+        { 8 { { 4 { 3 2 } } { 0 { } } } }
+        { 9 { { 4 { 3 2 } } { 0 { } } } }
+        { 10 { { 4 { 3 2 } } { 0 { } } } }
+        { 11 { { 4 { 3 2 } } { 0 { } } } }
+        { 12 { { 4 { 3 2 } } { 0 { } } } }
+        { 13 { { 4 { 3 2 1 } } { 0 { } } } }
+        { 14 { { 7 { 6 5 4 } } { 0 { } } } }
+        { 15 { { 7 { 6 5 4 } } { 0 { } } } }
+        { 16 { { 7 { 6 5 4 0 } } { 0 { } } } }
+        { 17 { { 7 { 6 5 4 0 3 } } { 0 { } } } }
+        { 18 { { 7 { 6 5 4 0 3 } } { 0 { } } } }
+        { 19 { { 7 { 6 5 4 0 3 1 } } { 0 { } } } }
+        { 20 { { 7 { 6 5 4 0 3 1 2 } } { 0 { } } } }
+        { 21 { { 4 { 3 2 1 -3 0 -2 -1 } } { 0 { } } } }
+        { 22 { { 4 { 3 2 1 -3 0 -2 -1 } } { 0 { } } } }
+    }
+} [
+    bug1021-cfg trace-stack-state
 ] unit-test

--- a/basis/compiler/cfg/stacks/map/map-tests.factor
+++ b/basis/compiler/cfg/stacks/map/map-tests.factor
@@ -1,0 +1,233 @@
+USING: accessors arrays assocs compiler.cfg
+compiler.cfg.dataflow-analysis.private compiler.cfg.instructions
+compiler.cfg.linearization compiler.cfg.registers
+compiler.cfg.utilities compiler.cfg.stacks.map kernel math namespaces
+sequences sorting tools.test vectors ;
+IN: compiler.cfg.stacks.map.tests
+
+! Utils
+: output-stack-map ( cfg -- map )
+    H{ } clone stack-record set
+    map-analysis run-dataflow-analysis
+    nip [ [ number>> ] dip ] assoc-map >alist natural-sort last second ;
+
+! Initially both the d and r stacks are empty.
+{
+    { { 0 { } } { 0 { } } }
+} [ V{ } insns>cfg output-stack-map ] unit-test
+
+! Raise d stack.
+{
+    { { 1 { } } { 0 { } } }
+} [ V{ T{ ##inc-d f 1 } } insns>cfg output-stack-map ] unit-test
+
+! Raise r stack.
+{
+    { { 0 { } } { 1 { } } }
+} [ V{ T{ ##inc-r f 1 } } insns>cfg output-stack-map ] unit-test
+
+{
+    H{
+        {
+            T{ ##inc-d { n 2 } }
+            { { 0 { } } { 0 { } } }
+        }
+        {
+            T{ ##peek { loc D 2 } }
+            { { 2 { } } { 0 { } } }
+        }
+        {
+            T{ ##inc-d { n 0 } }
+            { { 2 { 0 1 2 } } { 0 { } } }
+        }
+
+    }
+} [
+    {
+        T{ ##inc-d f 2 }
+        T{ ##peek f f D 2 }
+        T{ ##inc-d f 0 }
+    } insns>cfg trace-stack-state
+] unit-test
+
+! Here the peek refers to a parameter of the word.
+[ ] [
+    V{
+        T{ ##peek { dst 0 } { loc D 25 } }
+    } insns>cfg
+    compute-map-sets
+] unit-test
+
+! Replace -1 then peek is ok.
+[ ] [
+    V{
+        T{ ##replace { src 10 } { loc D -1 } }
+        T{ ##peek { dst 0 } { loc D -1 } }
+    } insns>cfg
+    compute-map-sets
+] unit-test
+
+! Should be ok because the value was at 0 when the gc ran.
+{ { -1 { -1 } } } [
+    V{
+        T{ ##replace { src 10 } { loc D 0 } }
+        T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
+        T{ ##inc-d f -1 }
+        T{ ##peek { dst 0 } { loc D -1 } }
+    } insns>cfg output-stack-map first
+] unit-test
+
+{
+    { { 0 { } } { 0 { } } }
+} [
+    V{ T{ ##safepoint } T{ ##prologue } T{ ##branch } }
+    insns>cfg output-stack-map
+] unit-test
+
+{
+    { { 0 { 0 1 2 } } { 0 { } } }
+} [
+    V{
+        T{ ##replace { src 10 } { loc D 0 } }
+        T{ ##replace { src 10 } { loc D 1 } }
+        T{ ##replace { src 10 } { loc D 2 } }
+    } insns>cfg output-stack-map
+] unit-test
+
+{
+    { { 1 { 1 0 } } { 0 { } } }
+} [
+    V{
+        T{ ##replace { src 10 } { loc D 0 } }
+        T{ ##inc-d f 1 }
+        T{ ##replace { src 10 } { loc D 0 } }
+    } insns>cfg output-stack-map
+] unit-test
+
+{
+    { 0 { 0 -1 } }
+} [
+    V{
+        T{ ##replace { src 10 } { loc D 0 } }
+        T{ ##inc-d f 1 }
+        T{ ##replace { src 10 } { loc D 0 } }
+        T{ ##inc-d f -1 }
+    } insns>cfg output-stack-map first
+] unit-test
+
+{
+    { 0 { -1 } }
+} [
+    V{
+        T{ ##inc-d f 1 }
+        T{ ##replace { src 10 } { loc D 0 } }
+        T{ ##inc-d f -1 }
+    } insns>cfg output-stack-map first
+] unit-test
+
+! ##call clears the overinitialized slots.
+{
+    { -1 { } }
+} [
+    V{
+        T{ ##replace { src 10 } { loc D 0 } }
+        T{ ##inc-d f -1 }
+        T{ ##call }
+    } insns>cfg output-stack-map first
+] unit-test
+
+: cfg1 ( -- cfg )
+    V{
+        T{ ##inc-d f 1 }
+        T{ ##replace { src 10 } { loc D 0 } }
+    } 0 insns>block
+    V{
+        T{ ##peek { dst 37 } { loc D 0 } }
+        T{ ##inc-d f -1 }
+    } 1 insns>block
+    1vector >>successors block>cfg ;
+
+{ { 0 { -1 } } } [ cfg1 output-stack-map first ] unit-test
+
+! Same cfg structure as the bug1021:run-test word but with
+! non-datastack instructions mostly omitted.
+: bug1021-cfg ( -- cfg )
+    {
+        { 0 V{ T{ ##safepoint } T{ ##prologue } T{ ##branch } } }
+        {
+            1 V{
+                T{ ##inc-d f 2 }
+                T{ ##replace { src 0 } { loc D 1 } }
+                T{ ##replace { src 0 } { loc D 0 } }
+            }
+        }
+        {
+            2 V{
+                T{ ##call { word <array> } }
+            }
+        }
+        {
+            3 V{
+                T{ ##inc-d f 2 }
+                T{ ##peek { dst 0 } { loc D 2 } }
+                T{ ##peek { dst 0 } { loc D 3 } }
+                T{ ##replace { src 0 } { loc D 2 } }
+                T{ ##replace { src 0 } { loc D 3 } }
+                T{ ##replace { src 0 } { loc D 1 } }
+            }
+        }
+        {
+            8 V{
+                T{ ##inc-d f 3 }
+                T{ ##peek { dst 0 } { loc D 5 } }
+                T{ ##replace { src 0 } { loc D 0 } }
+                T{ ##replace { src 0 } { loc D 3 } }
+                T{ ##peek { dst 0 } { loc D 4 } }
+                T{ ##replace { src 0 } { loc D 1 } }
+                T{ ##replace { src 0 } { loc D 2 } }
+            }
+        }
+        {
+            10 V{
+                T{ ##inc-d f -3 }
+                T{ ##peek { dst 0 } { loc D -3 } }
+                T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
+            }
+        }
+    } [ over insns>block ] assoc-map dup
+    { { 0 1 } { 1 2 } { 2 3 } { 3 8 } { 8 10 } } make-edges 0 of block>cfg ;
+
+{ { 4 { 3 2 1 -3 0 -2 -1 } } } [
+    bug1021-cfg output-stack-map first
+] unit-test
+
+
+! After a ##peek that can cause a stack underflow, it is certain that
+! all stack locations are initialized.
+{
+    { { 2 { 0 1 2 } } { 0 { } } }
+} [
+    { { 2 { } } { 0 { } } } T{ ##peek f f D 2 } visit-insn
+] unit-test
+
+! If the ##peek can't cause a stack underflow, then we don't have the
+! same guarantees.
+{
+    { { 2 { 0 } } { 0 { } } }
+} [
+    { { 2 { } } { 0 { } } } T{ ##peek f f D 0 } visit-insn
+] unit-test
+
+{ t f t } [
+    { { 0 { } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-peek?
+    { { 0 { } } { 0 { } } } T{ ##peek { loc D -1 } } dangerous-peek?
+    { { 2 { 0 1 2 } } { 0 { } } } T{ ##peek { loc D 2 } } dangerous-peek?
+] unit-test
+
+{
+    { { 0 { } } { 2 { 0 1 } } }
+    { { 0 { } } { 2 { 0 1 } } }
+} [
+    { { 0 { } } { 2 { } } } fill-vacancies
+    { { 0 { } } { 2 { 0 } } } fill-vacancies
+] unit-test

--- a/basis/compiler/cfg/stacks/map/map.factor
+++ b/basis/compiler/cfg/stacks/map/map.factor
@@ -1,0 +1,74 @@
+USING: accessors arrays assocs compiler.cfg.dataflow-analysis
+compiler.cfg.instructions compiler.cfg.registers fry kernel math math.order
+namespaces sequences ;
+QUALIFIED: sets
+IN: compiler.cfg.stacks.map
+
+! Operations on the stack info
+: register-write ( n stack -- stack' )
+    first2 rot suffix sets:members 2array ;
+
+: adjust-stack ( n stack -- stack' )
+    first2 pick '[ _ + ] map [ + ] dip 2array ;
+
+: stack>vacant ( stack -- seq )
+    first2 [ 0 max iota ] dip sets:diff ;
+
+CONSTANT: initial-state { { 0 { } } { 0 { } } }
+
+: insn>location ( insn -- n ds? )
+    loc>> [ n>> ] [ ds-loc? ] bi ;
+
+: mark-location ( state insn -- state' )
+    [ first2 ] dip insn>location
+    [ rot register-write swap ] [ swap register-write ] if 2array ;
+
+: state>vacancies ( state -- vacants )
+    [ stack>vacant ] map ;
+
+: fill-vacancies ( state -- state' )
+    dup state>vacancies [ [ first2 ] dip append 2array ] 2map ;
+
+GENERIC: visit-insn ( state insn -- state' )
+
+M: ##inc-d visit-insn ( state insn -- state' )
+    n>> swap first2 [ adjust-stack ] dip 2array ;
+
+M: ##inc-r visit-insn ( state insn -- state' )
+    n>> swap first2 swapd adjust-stack 2array ;
+
+M: ##replace-imm visit-insn mark-location ;
+M: ##replace visit-insn mark-location ;
+
+M: ##call visit-insn ( state insn -- state' )
+    ! After a word call, we can't trust any overinitialized locations
+    ! to contain valid pointers anymore.
+    drop [ first2 [ 0 >= ] filter 2array ] map ;
+
+: dangerous-peek? ( state peek -- ? )
+    loc>> [ ds-loc? 0 1 ? swap nth first ] keep n>> <= ;
+
+M: ##peek visit-insn ( state insn -- state' )
+    2dup dangerous-peek? [ [ fill-vacancies ] dip ] when mark-location ;
+
+M: insn visit-insn ( state insn -- state' )
+    drop ;
+
+FORWARD-ANALYSIS: map
+
+SYMBOL: stack-record
+
+M: map-analysis transfer-set ( in-set bb dfa -- out-set )
+    drop instructions>> swap [
+        [ stack-record get set-at ] [ visit-insn ] 2bi
+    ] reduce ;
+
+M: map-analysis ignore-block? ( bb dfa -- ? )
+    2drop f ;
+
+! Picking the first means that a block will only be analyzed once.
+M: map-analysis join-sets ( sets bb dfa -- set )
+    2drop [ initial-state ] [ first ] if-empty ;
+
+: trace-stack-state ( cfg -- assoc )
+    H{ } clone stack-record set compute-map-sets stack-record get ;

--- a/basis/compiler/cfg/stacks/vacant/vacant-docs.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant-docs.factor
@@ -1,4 +1,5 @@
-USING: compiler.cfg.instructions help.markup help.syntax sequences strings ;
+USING: compiler.cfg compiler.cfg.instructions help.markup help.syntax sequences
+strings ;
 IN: compiler.cfg.stacks.vacant
 
 ARTICLE: "compiler.cfg.stacks.vacant" "Uninitialized/overinitialized stack location analysis"
@@ -35,5 +36,9 @@ HELP: overinitialized>bits
   { "bits" "sequence of 1:s and 0:s" }
 }
 { $description "Converts a sequence of overinitialized stack locations to the pattern of 1:s and 0:s that can be put in the " { $slot "check-d" } " and " { $slot "check-r" } " slots of a " { $link gc-map } ". 0:s are initialized locations and 0:s are empty ones. First element is stack location -1,second -2 and so on." } ;
+
+HELP: fill-gc-maps
+{ $values { "cfg" cfg } }
+{ $description "Populates the scrub-d, check-d, scrub-r and check-r slots of all gc maps in the cfg." } ;
 
 ABOUT: "compiler.cfg.stacks.vacant"

--- a/basis/compiler/cfg/stacks/vacant/vacant-docs.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant-docs.factor
@@ -12,8 +12,8 @@ ARTICLE: "compiler.cfg.stacks.vacant" "Uninitialized/overinitialized stack locat
 }
 "The GC check runs before stack locations 0 and 1 have been initialized, and so the GC needs to scrub them so that they don't get traced. This is achieved by computing uninitialized locations with a dataflow analysis, and recording the information in GC maps. The call_frame_slot_visitor object in vm/slot_visitor.hpp reads this information from GC maps and performs the scrubbing." ;
 
-HELP: initial-state
-{ $description "Initially the stack bottom is at 0 for both the data and retain stacks and no replaces have been registered." } ;
+! HELP: initial-state
+! { $description "Initially the stack bottom is at 0 for both the data and retain stacks and no replaces have been registered." } ;
 
 HELP: vacant>bits
 { $values

--- a/basis/compiler/cfg/stacks/vacant/vacant-tests.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant-tests.factor
@@ -5,59 +5,10 @@ compiler.cfg.utilities compiler.cfg.stacks.vacant kernel math sequences sorting
 tools.test vectors ;
 IN: compiler.cfg.stacks.vacant.tests
 
-! Utils
-: output-stack-map ( cfg -- map )
-    vacant-analysis run-dataflow-analysis
-    nip [ [ number>> ] dip ] assoc-map >alist natural-sort last second ;
-
-! Initially both the d and r stacks are empty.
 {
-    { { 0 { } } { 0 { } } }
-} [ V{ } insns>cfg output-stack-map ] unit-test
-
-! Raise d stack.
-{
-    { { 1 { } } { 0 { } } }
-} [ V{ T{ ##inc-d f 1 } } insns>cfg output-stack-map ] unit-test
-
-! Raise r stack.
-{
-    { { 0 { } } { 1 { } } }
-} [ V{ T{ ##inc-r f 1 } } insns>cfg output-stack-map ] unit-test
-
-! Uninitialized peeks
-[
-    V{
-        T{ ##inc-d f 1 }
-        T{ ##peek { dst 0 } { loc D 0 } }
-    } insns>cfg
-    compute-vacant-sets
-] [ vacant-peek? ] must-fail-with
-
-[
-    V{
-        T{ ##inc-r f 1 }
-        T{ ##peek { dst 0 } { loc R 0 } }
-    } insns>cfg
-    compute-vacant-sets
-] [ vacant-peek? ] must-fail-with
-
-
-! Here the peek refers to a parameter of the word.
-[ ] [
-    V{
-        T{ ##peek { dst 0 } { loc D 0 } }
-    } insns>cfg
-    compute-vacant-sets
-] unit-test
-
-! Replace -1 then peek is ok.
-[ ] [
-    V{
-        T{ ##replace { src 10 } { loc D -1 } }
-        T{ ##peek { dst 0 } { loc D -1 } }
-    } insns>cfg
-    compute-vacant-sets
+    { { { } { 0 0 0 } } { { } { 0 } } }
+} [
+    { { 4 { 3 2 1 -3 0 -2 -1 } } { 0 { -1 } } } state>gc-data
 ] unit-test
 
 ! Replace -1, then gc. Peek is ok here because the -1 should be
@@ -68,164 +19,99 @@ IN: compiler.cfg.stacks.vacant.tests
         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
         T{ ##peek { dst 0 } { loc D -1 } }
     }
-    [ insns>cfg compute-vacant-sets ]
+    [ insns>cfg fill-in-gc-maps ]
     [ second gc-map>> check-d>> ] bi
 ] unit-test
 
-! Should be ok because the value was at 0 when the gc ran.
-{ { -1 { -1 } } } [
-    V{
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
-        T{ ##inc-d f -1 }
-        T{ ##peek { dst 0 } { loc D -1 } }
-    } insns>cfg output-stack-map first
-] unit-test
+! ! Replace -1, then gc. Peek is ok here because the -1 should be
+! ! checked.
+! { { 0 } } [
+!     V{
+!         T{ ##replace { src 10 } { loc D -1 } }
+!         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
+!         T{ ##peek { dst 0 } { loc D -1 } }
+!     }
+!     [ insns>cfg compute-vacant-sets ]
+!     [ second gc-map>> check-d>> ] bi
+! ] unit-test
 
-! Should not be ok because the value wasn't initialized when gc ran.
-[
-    V{
-        T{ ##inc-d f 1 }
-        T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
-        T{ ##peek { dst 0 } { loc D 0 } }
-    } insns>cfg
-    compute-vacant-sets
-] [ vacant-peek? ] must-fail-with
+! ! Should not be ok because the value wasn't initialized when gc ran.
+! [
+!     V{
+!         T{ ##inc-d f 1 }
+!         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
+!         T{ ##peek { dst 0 } { loc D 0 } }
+!     } insns>cfg
+!     compute-vacant-sets
+! ] [ vacant-peek? ] must-fail-with
 
 ! visit-insn should set the gc info.
 { { 0 0 } { } } [
     { { 2 { } } { 0 { } } }
     T{ ##alien-invoke { gc-map T{ gc-map } } }
-    [ visit-insn drop ] keep gc-map>> [ scrub-d>> ] [ scrub-r>> ] bi
+    [ gc-map>> set-gc-map ] keep gc-map>> [ scrub-d>> ] [ scrub-r>> ] bi
 ] unit-test
 
-{
-    { { 0 { } } { 0 { } } }
-} [
-    V{ T{ ##safepoint } T{ ##prologue } T{ ##branch } }
-    insns>cfg output-stack-map
-] unit-test
 
-{
-    { { 0 { 0 1 2 } } { 0 { } } }
-} [
-    V{
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##replace { src 10 } { loc D 1 } }
-        T{ ##replace { src 10 } { loc D 2 } }
-    } insns>cfg output-stack-map
-] unit-test
+! ! read-ok?
+! { t } [
+!     0 { 0 { 0 1 2 } } read-ok?
+! ] unit-test
 
-{
-    { { 1 { 1 0 } } { 0 { } } }
-} [
-    V{
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##inc-d f 1 }
-        T{ ##replace { src 10 } { loc D 0 } }
-    } insns>cfg output-stack-map
-] unit-test
+! { f } [
+!     2 { 3 { } } read-ok?
+! ] unit-test
 
-{
-    { 0 { 0 -1 } }
-} [
-    V{
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##inc-d f 1 }
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##inc-d f -1 }
-    } insns>cfg output-stack-map first
-] unit-test
+! { f } [
+!     -1 { 3 { } } read-ok?
+! ] unit-test
 
-{
-    { 0 { -1 } }
-} [
-    V{
-        T{ ##inc-d f 1 }
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##inc-d f -1 }
-    } insns>cfg output-stack-map first
-] unit-test
+! ! { f } [
+! !     4 { 3 { } } read-ok?
+! ! ] unit-test
 
-{
-    { { { } { 0 0 0 } } { { } { 0 } } }
-} [
-    { { 4 { 3 2 1 -3 0 -2 -1 } } { 0 { -1 } } } state>gc-data
-] unit-test
+! { t } [
+!     4 { 0 { } } read-ok?
+! ] unit-test
 
-! ##call clears the overinitialized slots.
-{
-    { -1 { } }
-} [
-    V{
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##inc-d f -1 }
-        T{ ##call }
-    } insns>cfg output-stack-map first
-] unit-test
+! { t } [
+!     4 { 1 { 0 } } read-ok?
+! ] unit-test
 
-: cfg1 ( -- cfg )
-    V{
-        T{ ##inc-d f 1 }
-        T{ ##replace { src 10 } { loc D 0 } }
-    } 0 insns>block
-    V{
-        T{ ##peek { dst 37 } { loc D 0 } }
-        T{ ##inc-d f -1 }
-    } 1 insns>block
-    1vector >>successors block>cfg ;
+! ! Uninitialized peeks
+! [
+!     V{
+!         T{ ##inc-d f 1 }
+!         T{ ##peek { dst 0 } { loc D 0 } }
+!     } insns>cfg
+!     compute-vacant-sets
+! ] [ vacant-peek? ] must-fail-with
 
-{ { 0 { -1 } } } [ cfg1 output-stack-map first ] unit-test
+! [
+!     V{
+!         T{ ##inc-r f 1 }
+!         T{ ##peek { dst 0 } { loc R 0 } }
+!     } insns>cfg
+!     compute-vacant-sets
+! ] [ vacant-peek? ] must-fail-with
 
-! Same cfg structure as the bug1021:run-test word but with
-! non-datastack instructions mostly omitted.
-: bug1021-cfg ( -- cfg )
-    {
-        { 0 V{ T{ ##safepoint } T{ ##prologue } T{ ##branch } } }
-        {
-            1 V{
-                T{ ##inc-d f 2 }
-                T{ ##replace { src 0 } { loc D 1 } }
-                T{ ##replace { src 0 } { loc D 0 } }
-            }
-        }
-        {
-            2 V{
-                T{ ##call { word <array> } }
-            }
-        }
-        {
-            3 V{
-                T{ ##inc-d f 2 }
-                T{ ##peek { dst 0 } { loc D 2 } }
-                T{ ##peek { dst 0 } { loc D 3 } }
-                T{ ##replace { src 0 } { loc D 2 } }
-                T{ ##replace { src 0 } { loc D 3 } }
-                T{ ##replace { src 0 } { loc D 1 } }
-            }
-        }
-        {
-            8 V{
-                T{ ##inc-d f 3 }
-                T{ ##peek { dst 0 } { loc D 5 } }
-                T{ ##replace { src 0 } { loc D 0 } }
-                T{ ##replace { src 0 } { loc D 3 } }
-                T{ ##peek { dst 0 } { loc D 4 } }
-                T{ ##replace { src 0 } { loc D 1 } }
-                T{ ##replace { src 0 } { loc D 2 } }
-            }
-        }
-        {
-            10 V{
+! ! Here again the peek refers to a parameter word, but there are
+! ! uninitialized stack locations. That probably isn't ok.
+! [
+!     V{
+!         T{ ##inc-d f 3 }
+!         T{ ##peek { dst 0 } { loc D 3 } }
+!     } insns>cfg
+!     compute-vacant-sets
+! ] [ vacant-peek? ] must-fail-with
 
-                T{ ##inc-d f -3 }
-                T{ ##peek { dst 0 } { loc D -3 } }
-                T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
-            }
-        }
-    } [ over insns>block ] assoc-map dup
-    { { 0 1 } { 1 2 } { 2 3 } { 3 8 } { 8 10 } } make-edges 0 of block>cfg ;
 
-{ { 4 { 3 2 1 -3 0 -2 -1 } } } [
-    bug1021-cfg output-stack-map first
-] unit-test
+! ! Should not be ok because the value wasn't initialized when gc ran.
+! ! [
+! !     V{
+! !         T{ ##inc-d f 1 }
+! !         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
+! !         T{ ##peek { dst 0 } { loc D 0 } }
+! !     } insns>cfg
+! !     compute-map-sets
+! ! ] [ vacant-peek? ] must-fail-with

--- a/basis/compiler/cfg/stacks/vacant/vacant-tests.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant-tests.factor
@@ -19,31 +19,21 @@ IN: compiler.cfg.stacks.vacant.tests
         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
         T{ ##peek { dst 0 } { loc D -1 } }
     }
-    [ insns>cfg fill-in-gc-maps ]
+    [ insns>cfg fill-gc-maps ]
     [ second gc-map>> check-d>> ] bi
 ] unit-test
 
-! ! Replace -1, then gc. Peek is ok here because the -1 should be
-! ! checked.
-! { { 0 } } [
-!     V{
-!         T{ ##replace { src 10 } { loc D -1 } }
-!         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
-!         T{ ##peek { dst 0 } { loc D -1 } }
-!     }
-!     [ insns>cfg compute-vacant-sets ]
-!     [ second gc-map>> check-d>> ] bi
-! ] unit-test
-
-! ! Should not be ok because the value wasn't initialized when gc ran.
-! [
-!     V{
-!         T{ ##inc-d f 1 }
-!         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
-!         T{ ##peek { dst 0 } { loc D 0 } }
-!     } insns>cfg
-!     compute-vacant-sets
-! ] [ vacant-peek? ] must-fail-with
+! Replace -1, then gc. Peek is ok here because the -1 should be
+! checked.
+{ { 0 } } [
+    V{
+        T{ ##replace { src 10 } { loc D -1 } }
+        T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
+        T{ ##peek { dst 0 } { loc D -1 } }
+    }
+    [ insns>cfg fill-gc-maps ]
+    [ second gc-map>> check-d>> ] bi
+] unit-test
 
 ! visit-insn should set the gc info.
 { { 0 0 } { } } [
@@ -51,67 +41,3 @@ IN: compiler.cfg.stacks.vacant.tests
     T{ ##alien-invoke { gc-map T{ gc-map } } }
     [ gc-map>> set-gc-map ] keep gc-map>> [ scrub-d>> ] [ scrub-r>> ] bi
 ] unit-test
-
-
-! ! read-ok?
-! { t } [
-!     0 { 0 { 0 1 2 } } read-ok?
-! ] unit-test
-
-! { f } [
-!     2 { 3 { } } read-ok?
-! ] unit-test
-
-! { f } [
-!     -1 { 3 { } } read-ok?
-! ] unit-test
-
-! ! { f } [
-! !     4 { 3 { } } read-ok?
-! ! ] unit-test
-
-! { t } [
-!     4 { 0 { } } read-ok?
-! ] unit-test
-
-! { t } [
-!     4 { 1 { 0 } } read-ok?
-! ] unit-test
-
-! ! Uninitialized peeks
-! [
-!     V{
-!         T{ ##inc-d f 1 }
-!         T{ ##peek { dst 0 } { loc D 0 } }
-!     } insns>cfg
-!     compute-vacant-sets
-! ] [ vacant-peek? ] must-fail-with
-
-! [
-!     V{
-!         T{ ##inc-r f 1 }
-!         T{ ##peek { dst 0 } { loc R 0 } }
-!     } insns>cfg
-!     compute-vacant-sets
-! ] [ vacant-peek? ] must-fail-with
-
-! ! Here again the peek refers to a parameter word, but there are
-! ! uninitialized stack locations. That probably isn't ok.
-! [
-!     V{
-!         T{ ##inc-d f 3 }
-!         T{ ##peek { dst 0 } { loc D 3 } }
-!     } insns>cfg
-!     compute-vacant-sets
-! ] [ vacant-peek? ] must-fail-with
-
-
-! ! Should not be ok because the value wasn't initialized when gc ran.
-! ! [
-! !     V{
-! !         T{ ##inc-d f 1 }
-! !         T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
-! !         T{ ##peek { dst 0 } { loc D 0 } }
-! !     } insns>cfg
-! !     compute-map-sets
-! ! ] [ vacant-peek? ] must-fail-with

--- a/basis/compiler/cfg/stacks/vacant/vacant.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant.factor
@@ -1,5 +1,5 @@
 USING: accessors arrays assocs compiler.cfg.instructions
-compiler.cfg.stacks.map fry kernel math sequences ;
+compiler.cfg.linearization compiler.cfg.stacks.map fry kernel math sequences ;
 IN: compiler.cfg.stacks.vacant
 
 ! ! Utils
@@ -31,5 +31,5 @@ IN: compiler.cfg.stacks.vacant
     { >>scrub-d >>check-d >>scrub-r >>check-r } write-slots ;
 
 : fill-gc-maps ( cfg -- )
-    trace-stack-state [ drop gc-map-insn? ] assoc-filter
-    [ swap gc-map>> set-gc-map ] assoc-each ;
+    [ trace-stack-state ] [ cfg>insns [ gc-map-insn? ] filter ] bi
+    [ [ insn#>> of ] [ gc-map>> ] bi set-gc-map ] with each ;

--- a/basis/compiler/cfg/stacks/vacant/vacant.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant.factor
@@ -1,24 +1,10 @@
-USING: accessors arrays compiler.cfg.dataflow-analysis
-compiler.cfg.instructions compiler.cfg.registers fry kernel math
-math.order sequences sets ;
+USING: accessors arrays assocs compiler.cfg.instructions
+compiler.cfg.stacks.map fry kernel math sequences ;
 IN: compiler.cfg.stacks.vacant
 
-! Utils
+! ! Utils
 : write-slots ( tuple values slots -- )
     [ execute( x y -- z ) ] 2each drop ;
-
-! Operations on the stack info
-: register-write ( n stack -- stack' )
-    first2 rot suffix members 2array ;
-
-: adjust-stack ( n stack -- stack' )
-    first2 pick '[ _ + ] map [ + ] dip 2array ;
-
-: read-ok? ( n stack -- ? )
-    [ first >= ] [ second in? ] 2bi or ;
-
-: stack>vacant ( stack -- seq )
-    first2 [ 0 max iota ] dip diff ;
 
 : vacant>bits ( vacant --  bits )
     [ { } ] [
@@ -40,57 +26,10 @@ IN: compiler.cfg.stacks.vacant
 : state>gc-data ( state -- gc-data )
     [ stack>scrub-and-check ] map ;
 
-CONSTANT: initial-state { { 0 { } } { 0 { } } }
-
-: insn>location ( insn -- n ds? )
-    loc>> [ n>> ] [ ds-loc? ] bi ;
-
-: visit-replace ( state insn -- state' )
-    [ first2 ] dip insn>location
-    [ rot register-write swap ] [ swap register-write ] if 2array ;
-
-ERROR: vacant-peek insn ;
-
-: peek-loc-ok? ( state insn -- ? )
-    insn>location 0 1 ? rot nth read-ok? ;
-
-GENERIC: visit-insn ( state insn -- state' )
-
-M: ##inc-d visit-insn ( state insn -- state' )
-    n>> swap first2 [ adjust-stack ] dip 2array ;
-
-M: ##inc-r visit-insn ( state insn -- state' )
-    n>> swap first2 swapd adjust-stack 2array ;
-
-M: ##replace-imm visit-insn visit-replace ;
-M: ##replace visit-insn visit-replace ;
-
-M: ##peek visit-insn ( state insn -- state' )
-    2dup peek-loc-ok? [ drop ] [ vacant-peek ] if ;
-
-M: ##call visit-insn ( state insn -- state' )
-    ! After a word call, we can't trust any overinitialized locations
-    ! to contain valid pointers anymore.
-    drop [ first2 [ 0 >= ] filter 2array ] map ;
-
 : set-gc-map ( state gc-map -- )
     swap state>gc-data concat
     { >>scrub-d >>check-d >>scrub-r >>check-r } write-slots ;
 
-M: gc-map-insn visit-insn ( state insn -- state' )
-    dupd gc-map>> set-gc-map ;
-
-M: insn visit-insn ( state insn -- state' )
-    drop ;
-
-FORWARD-ANALYSIS: vacant
-
-M: vacant-analysis transfer-set ( in-set bb dfa -- out-set )
-    drop instructions>> swap [ visit-insn ] reduce ;
-
-M: vacant-analysis ignore-block? ( bb dfa -- ? )
-    2drop f ;
-
-! Picking the first means that a block will only be analyzed once.
-M: vacant-analysis join-sets ( sets bb dfa -- set )
-    2drop [ initial-state ] [ first ] if-empty ;
+: fill-gc-maps ( cfg -- )
+    trace-stack-state [ drop gc-map-insn? ] assoc-filter
+    [ swap gc-map>> set-gc-map ] assoc-each ;

--- a/extra/tools/gc-decode/gc-decode-tests.factor
+++ b/extra/tools/gc-decode/gc-decode-tests.factor
@@ -27,7 +27,7 @@ IN: tools.gc-decode.tests
 { t } [
     \ effects:<effect> word>gc-info scrub-bits
     {
-        ?{ t t t f t t t t } ! 64-bit
+        ?{ t t t t f t t t t } ! 64-bit
         ?{ t t t f f f f f t t t t } ! 32-bit
     } member?
 ] unit-test


### PR DESCRIPTION
Here is another fix for the really annoying #1187 bug. E.g

    10 [ [ minor-gc split-slice ] [ drop ] recover ] times

doesn't crash. :) So the problem is that there may be uninitialized holes in the stacks. Which works fine until a `##peek` instruction looks at a stack slot above the known height and causes a stack underflow. Then the GC code tries to trace all slots on the stacks and that crashes because of the uninitialized slots. It's the same kind of problem that the gc maps solves.

So I've added a step compiler pass called `clear-uninitialized` which finds `##peek`s that can cause underflows and inserts `##replace-imm` instructions preceding those to initialize the stack slots with dummy values. I also had to detach the `normalize-height` and `schedule-instructions` passes because the way they reordered the instructions caused to many uninitialized slots which caused to many ##replace-imm's to be inserted. 

There is some overhead, but not to much I think. The mean size per word increases from 386 to 391 bytes on 32 bit and 459 to 460 on 64 bit. 

