### PR TITLE
tools.gc-decode.tests: make test case work on 32 bit

### DIFF
--- a/extra/tools/gc-decode/gc-decode-tests.factor
+++ b/extra/tools/gc-decode/gc-decode-tests.factor
@@ -28,7 +28,7 @@ IN: tools.gc-decode.tests
     \ effects:<effect> word>gc-info scrub-bits
     {
         ?{ t t t t f t t t t } ! 64-bit
-        ?{ t t t f f f f f t t t t } ! 32-bit
+        ?{ t t t t f f f f f t t t t } ! 32-bit
     } member?
 ] unit-test
 


### PR DESCRIPTION
Here is the gc-decode test fail fix.