### PR TITLE
Refactor debug

### DIFF
--- a/vm/debug.cpp
+++ b/vm/debug.cpp
@@ -1,31 +1,33 @@
 #include "master.hpp"
 
+using namespace std;
+
 namespace factor {
 
-std::ostream& operator<<(std::ostream& out, const string* str) {
+ostream& operator<<(ostream& out, const string* str) {
   for (cell i = 0; i < string_capacity(str); i++)
     out << (char)str->data()[i];
   return out;
 }
 
-void factor_vm::print_word(word* word, cell nesting) {
+void factor_vm::print_word(ostream& out, word* word, cell nesting) {
   if (tagged<object>(word->vocabulary).type_p(STRING_TYPE))
-    std::cout << untag<string>(word->vocabulary) << ":";
+    out << untag<string>(word->vocabulary) << ":";
 
   if (tagged<object>(word->name).type_p(STRING_TYPE))
-    std::cout << untag<string>(word->name);
+    out << untag<string>(word->name);
   else {
-    std::cout << "#<not a string: ";
-    print_nested_obj(word->name, nesting);
-    std::cout << ">";
+    out << "#<not a string: ";
+    print_nested_obj(out, word->name, nesting);
+    out << ">";
   }
 }
 
-void factor_vm::print_factor_string(string* str) {
-  std::cout << '"' << str << '"';
+void factor_vm::print_factor_string(ostream& out, string* str) {
+  out << '"' << str << '"';
 }
 
-void factor_vm::print_array(array* array, cell nesting) {
+void factor_vm::print_array(ostream& out, array* array, cell nesting) {
   cell length = array_capacity(array);
   cell i;
   bool trimmed;
@@ -37,27 +39,27 @@ void factor_vm::print_array(array* array, cell nesting) {
     trimmed = false;
 
   for (i = 0; i < length; i++) {
-    std::cout << " ";
-    print_nested_obj(array_nth(array, i), nesting);
+    out << " ";
+    print_nested_obj(out, array_nth(array, i), nesting);
   }
 
   if (trimmed)
-    std::cout << "...";
+    out << "...";
 }
 
-void factor_vm::print_alien(alien* alien, cell nesting) {
+void factor_vm::print_alien(ostream& out, alien* alien, cell nesting) {
   if (to_boolean(alien->expired))
-    std::cout << "#<expired alien>";
+    out << "#<expired alien>";
   else if (to_boolean(alien->base)) {
-    std::cout << "#<displaced alien " << alien->displacement << "+";
-    print_nested_obj(alien->base, nesting);
-    std::cout << ">";
+    out << "#<displaced alien " << alien->displacement << "+";
+    print_nested_obj(out, alien->base, nesting);
+    out << ">";
   } else {
-    std::cout << "#<alien " << (void*)alien->address << ">";
+    out << "#<alien " << (void*)alien->address << ">";
   }
 }
 
-void factor_vm::print_byte_array(byte_array* array, cell nesting) {
+void factor_vm::print_byte_array(ostream& out, byte_array* array, cell nesting) {
   cell length = array->capacity;
   cell i;
   bool trimmed;
@@ -70,19 +72,19 @@ void factor_vm::print_byte_array(byte_array* array, cell nesting) {
     trimmed = false;
 
   for (i = 0; i < length; i++) {
-    std::cout << " " << (unsigned) data[i];
+    out << " " << (unsigned) data[i];
   }
 
   if (trimmed)
-    std::cout << "...";
+    out << "...";
 }
 
-void factor_vm::print_tuple(tuple* tuple, cell nesting) {
+void factor_vm::print_tuple(ostream& out, tuple* tuple, cell nesting) {
   tuple_layout* layout = untag<tuple_layout>(tuple->layout);
   cell length = to_cell(layout->size);
 
-  std::cout << " ";
-  print_nested_obj(layout->klass, nesting);
+  out << " ";
+  print_nested_obj(out, layout->klass, nesting);
 
   bool trimmed;
   if (length > 10 && !full_output) {
@@ -92,17 +94,17 @@ void factor_vm::print_tuple(tuple* tuple, cell nesting) {
     trimmed = false;
 
   for (cell i = 0; i < length; i++) {
-    std::cout << " ";
-    print_nested_obj(tuple->data()[i], nesting);
+    out << " ";
+    print_nested_obj(out, tuple->data()[i], nesting);
   }
 
   if (trimmed)
-    std::cout << "...";
+    out << "...";
 }
 
-void factor_vm::print_nested_obj(cell obj, fixnum nesting) {
+void factor_vm::print_nested_obj(ostream& out, cell obj, fixnum nesting) {
   if (nesting <= 0 && !full_output) {
-    std::cout << " ... ";
+    out << " ... ";
     return;
   }
 
@@ -110,118 +112,126 @@ void factor_vm::print_nested_obj(cell obj, fixnum nesting) {
 
   switch (tagged<object>(obj).type()) {
     case FIXNUM_TYPE:
-      std::cout << untag_fixnum(obj);
+      out << untag_fixnum(obj);
       break;
     case FLOAT_TYPE:
-      std::cout << untag_float(obj);
+      out << untag_float(obj);
       break;
     case WORD_TYPE:
-      print_word(untag<word>(obj), nesting - 1);
+      print_word(out, untag<word>(obj), nesting - 1);
       break;
     case STRING_TYPE:
-      print_factor_string(untag<string>(obj));
+      print_factor_string(out, untag<string>(obj));
       break;
     case F_TYPE:
-      std::cout << "f";
+      out << "f";
       break;
     case TUPLE_TYPE:
-      std::cout << "T{";
-      print_tuple(untag<tuple>(obj), nesting - 1);
-      std::cout << " }";
+      out << "T{";
+      print_tuple(out, untag<tuple>(obj), nesting - 1);
+      out << " }";
       break;
     case WRAPPER_TYPE:
-      std::cout << "W{ ";
-      print_nested_obj(untag<wrapper>(obj)->object, nesting - 1);
-      std::cout << " }";
+      out << "W{ ";
+      print_nested_obj(out, untag<wrapper>(obj)->object, nesting - 1);
+      out << " }";
       break;
     case BYTE_ARRAY_TYPE:
-      std::cout << "B{";
-      print_byte_array(untag<byte_array>(obj), nesting - 1);
-      std::cout << " }";
+      out << "B{";
+      print_byte_array(out, untag<byte_array>(obj), nesting - 1);
+      out << " }";
       break;
     case ARRAY_TYPE:
-      std::cout << "{";
-      print_array(untag<array>(obj), nesting - 1);
-      std::cout << " }";
+      out << "{";
+      print_array(out, untag<array>(obj), nesting - 1);
+      out << " }";
       break;
     case QUOTATION_TYPE:
-      std::cout << "[";
+      out << "[";
       quot = untag<quotation>(obj);
-      print_array(untag<array>(quot->array), nesting - 1);
-      std::cout << " ]";
+      print_array(out, untag<array>(quot->array), nesting - 1);
+      out << " ]";
       break;
     case ALIEN_TYPE:
-      print_alien(untag<alien>(obj), nesting - 1);
+      print_alien(out, untag<alien>(obj), nesting - 1);
       break;
     default:
-      std::cout << "#<" << type_name(tagged<object>(obj).type()) << " @ ";
-      std::cout << (void*)obj << ">";
+      out << "#<" << type_name(tagged<object>(obj).type()) << " @ ";
+      out << (void*)obj << ">";
       break;
   }
-  std::cout << std::flush;
+  out << flush;
 }
 
-void factor_vm::print_obj(cell obj) { print_nested_obj(obj, 10); }
+void factor_vm::print_obj(ostream& out, cell obj) {
+  print_nested_obj(out, obj, 10);
+}
 
-void factor_vm::print_objects(cell* start, cell* end) {
+void factor_vm::print_objects(ostream& out, cell* start, cell* end) {
   for (; start <= end; start++) {
-    print_obj(*start);
-    std::cout << std::endl;
+    print_obj(out, *start);
+    cout << endl;
   }
 }
 
-void factor_vm::print_datastack() {
-  std::cout << "==== DATA STACK:" << std::endl;
+void factor_vm::print_datastack(ostream& out) {
+  out << "==== DATA STACK:" << endl;
   if (ctx)
-    print_objects((cell*)ctx->datastack_seg->start, (cell*)ctx->datastack);
+    print_objects(out,
+                  (cell*)ctx->datastack_seg->start,
+                  (cell*)ctx->datastack);
   else
-    std::cout << "*** Context not initialized" << std::endl;
+    out << "*** Context not initialized" << endl;
 }
 
-void factor_vm::print_retainstack() {
-  std::cout << "==== RETAIN STACK:" << std::endl;
+void factor_vm::print_retainstack(ostream& out) {
+  out << "==== RETAIN STACK:" << endl;
   if (ctx)
-    print_objects((cell*)ctx->retainstack_seg->start, (cell*)ctx->retainstack);
+    print_objects(out,
+                  (cell*)ctx->retainstack_seg->start,
+                  (cell*)ctx->retainstack);
   else
-    std::cout << "*** Context not initialized" << std::endl;
+    out << "*** Context not initialized" << endl;
 }
 
 struct stack_frame_printer {
   factor_vm* parent;
+  ostream& out;
 
-  explicit stack_frame_printer(factor_vm* parent) : parent(parent) {}
+  explicit stack_frame_printer(factor_vm* parent, ostream& out)
+      : parent(parent), out(out) {}
   void operator()(cell frame_top, cell size, code_block* owner, cell addr) {
-    std::cout << std::endl;
-    std::cout << "frame: " << (void*)frame_top << " size " << size << std::endl;
-    std::cout << "executing: ";
-    parent->print_obj(owner->owner);
-    std::cout << std::endl;
-    std::cout << "scan: ";
-    parent->print_obj(owner->scan(parent, addr));
-    std::cout << std::endl;
-    std::cout << "word/quot addr: ";
-    std::cout << std::hex << owner->owner << std::dec;
-    std::cout << std::endl;
-    std::cout << "word/quot xt: ";
-    std::cout << std::hex << owner->entry_point() << std::dec;
-    std::cout << std::endl;
-    std::cout << "return address: ";
-    std::cout << std::hex << addr << std::dec;
-    std::cout << std::endl;
+    out << endl;
+    out << "frame: " << (void*)frame_top << " size " << size << endl;
+    out << "executing: ";
+    parent->print_obj(out, owner->owner);
+    out << endl;
+    out << "scan: ";
+    parent->print_obj(out, owner->scan(parent, addr));
+    out << endl;
+    out << "word/quot addr: ";
+    out << hex << owner->owner << dec;
+    out << endl;
+    out << "word/quot xt: ";
+    out << hex << owner->entry_point() << dec;
+    out << endl;
+    out << "return address: ";
+    out << hex << addr << dec;
+    out << endl;
   }
 };
 
-void factor_vm::print_callstack() {
-  std::cout << "==== CALL STACK:" << std::endl;
+void factor_vm::print_callstack(ostream& out) {
+  out << "==== CALL STACK:" << endl;
   if (ctx) {
-    stack_frame_printer printer(this);
+    stack_frame_printer printer(this, out);
     iterate_callstack(ctx, printer);
   } else
-    std::cout << "*** Context not initialized" << std::endl;
+    out << "*** Context not initialized" << endl;
 }
 
-void factor_vm::print_callstack_object(callstack* obj) {
-  stack_frame_printer printer(this);
+void factor_vm::print_callstack_object(ostream& out, callstack* obj) {
+  stack_frame_printer printer(this, out);
   iterate_callstack_object(obj, printer);
 }
 
@@ -231,69 +241,69 @@ struct padded_address {
   explicit padded_address(cell value) : value(value) {}
 };
 
-std::ostream& operator<<(std::ostream& out, const padded_address& value) {
+ostream& operator<<(ostream& out, const padded_address& value) {
   char prev = out.fill('0');
   out.width(sizeof(cell) * 2);
-  out << std::hex << value.value << std::dec;
+  out << hex << value.value << dec;
   out.fill(prev);
   return out;
 }
 
-void factor_vm::dump_cell(cell x) {
-  std::cout << padded_address(x) << ": ";
+void factor_vm::dump_cell(ostream& out, cell x) {
+  out << padded_address(x) << ": ";
   x = *(cell*)x;
-  std::cout << padded_address(x) << " tag " << TAG(x) << std::endl;
+  out << padded_address(x) << " tag " << TAG(x) << endl;
 }
 
-void factor_vm::dump_memory(cell from, cell to) {
+void factor_vm::dump_memory(ostream& out, cell from, cell to) {
   from = UNTAG(from);
 
   for (; from <= to; from += sizeof(cell))
-    dump_cell(from);
+    dump_cell(out, from);
 }
 
 template <typename Generation>
-void factor_vm::dump_generation(const char* name, Generation* gen) {
-  std::cout << name << ": ";
-  std::cout << "Start=" << gen->start;
-  std::cout << ", size=" << gen->size;
-  std::cout << ", end=" << gen->end;
-  std::cout << std::endl;
+void factor_vm::dump_generation(ostream& out, const char* name, Generation* gen) {
+  out << name << ": ";
+  out << "Start=" << gen->start;
+  out << ", size=" << gen->size;
+  out << ", end=" << gen->end;
+  out << endl;
 }
 
-void factor_vm::dump_generations() {
-  std::cout << std::hex;
+void factor_vm::dump_generations(ostream& out) {
+  out << hex;
 
-  dump_generation("Nursery", &nursery);
-  dump_generation("Aging", data->aging);
-  dump_generation("Tenured", data->tenured);
+  dump_generation(out, "Nursery", &nursery);
+  dump_generation(out, "Aging", data->aging);
+  dump_generation(out, "Tenured", data->tenured);
 
-  std::cout << "Cards:";
-  std::cout << "base=" << (cell)data->cards << ", ";
-  std::cout << "size=" << (cell)(data->cards_end - data->cards) << std::endl;
-
-  std::cout << std::dec;
+  out << "Cards:";
+  out << "base=" << (cell)data->cards << ", ";
+  out << "size=" << (cell)(data->cards_end - data->cards) << endl;
+  out << dec;
 }
 
 struct object_dumper {
   factor_vm* parent;
   cell type;
+  ostream& out;
 
-  object_dumper(factor_vm* parent, cell type)
-      : parent(parent), type(type) {}
+  object_dumper(factor_vm* parent, cell type, ostream& out)
+      : parent(parent), type(type), out(out) {}
 
   void operator()(object* obj) {
     if (type == TYPE_COUNT || obj->type() == type) {
-      std::cout << padded_address((cell)obj) << " ";
-      parent->print_nested_obj(tag_dynamic(obj), 2);
-      std::cout << std::endl;
+      out << padded_address((cell)obj) << " ";
+      parent->print_nested_obj(out, tag_dynamic(obj), 2);
+      out << endl;
     }
   }
 };
 
-void factor_vm::dump_objects(cell type) {
+void factor_vm::dump_objects(ostream& out, cell type) {
   primitive_full_gc();
-  object_dumper dumper(this, type);
+  object_dumper dumper(this, type, out);
   each_object(dumper);
 }
 
@@ -301,16 +311,19 @@ struct find_data_reference_slot_visitor {
   cell look_for;
   object* obj;
   factor_vm* parent;
+  ostream& out;
 
-  find_data_reference_slot_visitor(cell look_for, object* obj,
-                                   factor_vm* parent)
-      : look_for(look_for), obj(obj), parent(parent) {}
+  find_data_reference_slot_visitor(cell look_for,
+                                   object* obj,
+                                   factor_vm* parent,
+                                   ostream& out)
+    : look_for(look_for), obj(obj), parent(parent), out(out) {}
 
   void operator()(cell* scan) {
     if (look_for == *scan) {
-      std::cout << padded_address((cell)obj) << " ";
-      parent->print_nested_obj(tag_dynamic(obj), 2);
-      std::cout << std::endl;
+      out << padded_address((cell)obj) << " ";
+      parent->print_nested_obj(out, tag_dynamic(obj), 2);
+      out << endl;
     }
   }
 };
@@ -318,47 +331,49 @@ struct find_data_reference_slot_visitor {
 struct dump_edges_slot_visitor {
   object* obj;
   factor_vm* parent;
+  ostream& out;
 
-  dump_edges_slot_visitor(cell, object* obj, factor_vm* parent)
-      : obj(obj), parent(parent) {}
+  dump_edges_slot_visitor(cell, object* obj, factor_vm* parent, ostream& out)
+      : obj(obj), parent(parent), out(out) {}
 
   void operator()(cell* scan) {
     if (TAG(*scan) > F_TYPE)
-      std::cout << (void*)tag_dynamic(obj) << " ==> " << (void*)*scan
-                << std::endl;
+      out << (void*)tag_dynamic(obj) << " ==> " << (void*)*scan << endl;
   }
 };
 
 template <typename SlotVisitor> struct data_reference_object_visitor {
   cell look_for;
   factor_vm* parent;
+  ostream& out;
 
-  data_reference_object_visitor(cell look_for, factor_vm* parent)
-      : look_for(look_for), parent(parent) {}
+  data_reference_object_visitor(cell look_for, factor_vm* parent, ostream& out)
+      : look_for(look_for), parent(parent), out(out) {}
 
   void operator()(object* obj) {
-    SlotVisitor visitor(look_for, obj, parent);
+    SlotVisitor visitor(look_for, obj, parent, out);
     obj->each_slot(visitor);
   }
 };
 
-void factor_vm::find_data_references(cell look_for) {
-  data_reference_object_visitor<find_data_reference_slot_visitor> visitor(
-      look_for, this);
+void factor_vm::find_data_references(ostream& out, cell look_for) {
+  data_reference_object_visitor<find_data_reference_slot_visitor>
+      visitor(look_for, this, out);
   each_object(visitor);
 }
 
-void factor_vm::dump_edges() {
-  data_reference_object_visitor<dump_edges_slot_visitor> visitor(0, this);
+void factor_vm::dump_edges(ostream& out) {
+  data_reference_object_visitor<dump_edges_slot_visitor> visitor(0, this, out);
   each_object(visitor);
 }
 
 struct code_block_printer {
   factor_vm* parent;
+  ostream& out;
   cell reloc_size, parameter_size;
 
-  explicit code_block_printer(factor_vm* parent)
-      : parent(parent), reloc_size(0), parameter_size(0) {}
+  explicit code_block_printer(factor_vm* parent, ostream& out)
+      : parent(parent), out(out), reloc_size(0), parameter_size(0) {}
 
   void operator()(code_block* scan, cell size) {
     const char* status;
@@ -373,73 +388,69 @@ struct code_block_printer {
       else
         status = "allocated";
 
-      std::cout << std::hex << (cell)scan << std::dec << " ";
-      std::cout << std::hex << size << std::dec << " ";
-      std::cout << status << " ";
-      std::cout << "stack frame " << scan->stack_frame_size();
-      std::cout << std::endl;
+      out << hex << (cell)scan << dec << " ";
+      out << hex << size << dec << " ";
+      out << status << " ";
+      out << "stack frame " << scan->stack_frame_size();
+      out << endl;
     }
   }
 };
 
 /* Dump all code blocks for debugging */
-void factor_vm::dump_code_heap() {
-  code_block_printer printer(this);
+void factor_vm::dump_code_heap(ostream& out) {
+  code_block_printer printer(this, out);
   code->allocator->iterate(printer);
-  std::cout << printer.reloc_size << " bytes used by relocation tables"
-            << std::endl;
-  std::cout << printer.parameter_size << " bytes used by parameter tables"
-            << std::endl;
+  out << printer.reloc_size << " bytes used by relocation tables" << endl;
+  out << printer.parameter_size << " bytes used by parameter tables" << endl;
 }
 
 void factor_vm::factorbug_usage(bool advanced_p) {
-  std::cout << "Basic commands:" << std::endl;
+  cout << "Basic commands:" << endl;
 #ifdef WINDOWS
-  std::cout << "  q ^Z             -- quit Factor" << std::endl;
+  cout << "  q ^Z             -- quit Factor" << endl;
 #else
-  std::cout << "  q ^D             -- quit Factor" << std::endl;
+  cout << "  q ^D             -- quit Factor" << endl;
 #endif
-  std::cout << "  c                -- continue executing Factor - NOT SAFE"
-            << std::endl;
-  std::cout << "  t                -- throw exception in Factor - NOT SAFE"
-            << std::endl;
-  std::cout << "  .s .r .c         -- print data, retain, call stacks"
-            << std::endl;
+  cout << "  c                -- continue executing Factor - NOT SAFE"
+       << endl;
+  cout << "  t                -- throw exception in Factor - NOT SAFE"
+       << endl;
+  cout << "  .s .r .c         -- print data, retain, call stacks"
+       << endl;
   if (advanced_p) {
-    std::cout << "  help             -- reprint this message" << std::endl;
-    std::cout << "Advanced commands:" << std::endl;
-    std::cout << "  e                -- dump environment" << std::endl;
-    std::cout << "  d <addr> <count> -- dump memory" << std::endl;
-    std::cout << "  u <addr>         -- dump object at tagged <addr>"
-              << std::endl;
-    std::cout << "  . <addr>         -- print object at tagged <addr>"
-              << std::endl;
-    std::cout << "  g                -- dump generations" << std::endl;
-    std::cout << "  ds dr            -- dump data, retain stacks" << std::endl;
-    std::cout << "  trim             -- toggle output trimming" << std::endl;
-    std::cout << "  data             -- data heap dump" << std::endl;
-    std::cout << "  words            -- words dump" << std::endl;
-    std::cout << "  tuples           -- tuples dump" << std::endl;
-    std::cout << "  edges            -- print all object-to-object references"
-              << std::endl;
-    std::cout << "  refs <addr>      -- find data heap references to object"
-              << std::endl;
-    std::cout << "  push <addr>      -- push object on data stack - NOT SAFE"
-              << std::endl;
-    std::cout << "  gc               -- trigger full GC - NOT SAFE"
-              << std::endl;
-    std::cout << "  compact-gc       -- trigger compacting GC - NOT SAFE"
-              << std::endl;
-    std::cout << "  code             -- code heap dump" << std::endl;
-    std::cout << "  abort            -- call abort()" << std::endl;
-    std::cout << "  breakpoint       -- trigger system breakpoint" << std::endl;
+    cout << "  help             -- reprint this message" << endl;
+    cout << "Advanced commands:" << endl;
+    cout << "  e                -- dump environment" << endl;
+    cout << "  d <addr> <count> -- dump memory" << endl;
+    cout << "  u <addr>         -- dump object at tagged <addr>"
+         << endl;
+    cout << "  . <addr>         -- print object at tagged <addr>"
+         << endl;
+    cout << "  g                -- dump generations" << endl;
+    cout << "  ds dr            -- dump data, retain stacks" << endl;
+    cout << "  trim             -- toggle output trimming" << endl;
+    cout << "  data             -- data heap dump" << endl;
+    cout << "  words            -- words dump" << endl;
+    cout << "  tuples           -- tuples dump" << endl;
+    cout << "  edges            -- print all object-to-object references"
+         << endl;
+    cout << "  refs <addr>      -- find data heap references to object"
+         << endl;
+    cout << "  push <addr>      -- push object on data stack - NOT SAFE"
+         << endl;
+    cout << "  gc               -- trigger full GC - NOT SAFE"
+         << endl;
+    cout << "  compact-gc       -- trigger compacting GC - NOT SAFE"
+         << endl;
+    cout << "  code             -- code heap dump" << endl;
+    cout << "  abort            -- call abort()" << endl;
+    cout << "  breakpoint       -- trigger system breakpoint" << endl;
   } else {
-    std::cout << "  help             -- full help, including advanced commands"
-              << std::endl;
+    cout << "  help             -- full help, including advanced commands"
+         << endl;
   }
-
-  std::cout << std::endl;
-
+  cout << endl;
 }
 
 static void exit_fep(factor_vm* vm) {
@@ -450,7 +461,7 @@ static void exit_fep(factor_vm* vm) {
 
 void factor_vm::factorbug() {
   if (fep_disabled) {
-    std::cout << "Low level debugger disabled" << std::endl;
+    cout << "Low level debugger disabled" << endl;
     exit(1);
   }
 
@@ -459,7 +470,7 @@ void factor_vm::factorbug() {
 
   fep_p = true;
 
-  std::cout << "Starting low level debugger..." << std::endl;
+  cout << "Starting low level debugger..." << endl;
 
   // Even though we've stopped the VM, the stdin_loop thread (see os-*.cpp)
   // that pumps the console is still running concurrently. We lock a mutex so
@@ -476,10 +487,10 @@ void factor_vm::factorbug() {
   for (;;) {
     std::string cmd;
 
-    std::cout << "> " << std::flush;
+    cout << "> " << flush;
 
-    std::cin >> std::setw(1024) >> cmd >> std::setw(0);
-    if (!std::cin.good()) {
+    cin >> setw(1024) >> cmd >> setw(0);
+    if (!cin.good()) {
       if (!seen_command) {
         /* If we exit with an EOF immediately, then
            dump stacks. This is useful for builder and
@@ -487,9 +498,9 @@ void factor_vm::factorbug() {
            redirected to /dev/null */
         fep_disabled = true;
 
-        print_datastack();
-        print_retainstack();
-        print_callstack();
+        print_datastack(cout);
+        print_retainstack(cout);
+        print_callstack(cout);
       }
 
       exit(1);
@@ -501,38 +512,38 @@ void factor_vm::factorbug() {
       exit(1);
     if (cmd == "d") {
       cell addr = read_cell_hex();
-      if (std::cin.peek() == ' ')
-        std::cin.ignore();
+      if (cin.peek() == ' ')
+        cin.ignore();
 
-      if (!std::cin.good())
+      if (!cin.good())
         break;
       cell count = read_cell_hex();
-      dump_memory(addr, addr + count);
+      dump_memory(cout, addr, addr + count);
     } else if (cmd == "u") {
       cell addr = read_cell_hex();
       cell count = object_size(addr);
-      dump_memory(addr, addr + count);
+      dump_memory(cout, addr, addr + count);
     } else if (cmd == ".") {
       cell addr = read_cell_hex();
-      print_obj(addr);
-      std::cout << std::endl;
+      print_obj(cout, addr);
+      cout << endl;
     } else if (cmd == "trim")
       full_output = !full_output;
     else if (cmd == "ds")
-      dump_memory(ctx->datastack_seg->start, ctx->datastack);
+      dump_memory(cout, ctx->datastack_seg->start, ctx->datastack);
     else if (cmd == "dr")
-      dump_memory(ctx->retainstack_seg->start, ctx->retainstack);
+      dump_memory(cout, ctx->retainstack_seg->start, ctx->retainstack);
     else if (cmd == ".s")
-      print_datastack();
+      print_datastack(cout);
     else if (cmd == ".r")
-      print_retainstack();
+      print_retainstack(cout);
     else if (cmd == ".c")
-      print_callstack();
+      print_callstack(cout);
     else if (cmd == "e") {
       for (cell i = 0; i < special_object_count; i++)
-        dump_cell((cell)&special_objects[i]);
+        dump_cell(cout, (cell)&special_objects[i]);
     } else if (cmd == "g")
-      dump_generations();
+      dump_generations(cout);
     else if (cmd == "c") {
       exit_fep(this);
       return;
@@ -541,23 +552,23 @@ void factor_vm::factorbug() {
       general_error(ERROR_INTERRUPT, false_object, false_object);
       FACTOR_ASSERT(false);
     } else if (cmd == "data")
-      dump_objects(TYPE_COUNT);
+      dump_objects(cout, TYPE_COUNT);
     else if (cmd == "edges")
-      dump_edges();
+      dump_edges(cout);
     else if (cmd == "refs") {
       cell addr = read_cell_hex();
-      std::cout << "Data heap references:" << std::endl;
-      find_data_references(addr);
-      std::cout << std::endl;
+      cout << "Data heap references:" << endl;
+      find_data_references(cout, addr);
+      cout << endl;
     } else if (cmd == "words")
-      dump_objects(WORD_TYPE);
+      dump_objects(cout, WORD_TYPE);
     else if (cmd == "tuples")
-      dump_objects(TUPLE_TYPE);
+      dump_objects(cout, TUPLE_TYPE);
     else if (cmd == "push") {
       cell addr = read_cell_hex();
       ctx->push(addr);
     } else if (cmd == "code")
-      dump_code_heap();
+      dump_code_heap(cout);
     else if (cmd == "compact-gc")
       primitive_compact_gc();
     else if (cmd == "gc")
@@ -571,15 +582,15 @@ void factor_vm::factorbug() {
     else if (cmd == "breakpoint")
       breakpoint();
     else
-      std::cout << "unknown command" << std::endl;
+      cout << "unknown command" << endl;
   }
 }
 
 void factor_vm::primitive_die() {
-  std::cout << "The die word was called by the library. Unless you called it "
-               "yourself," << std::endl;
-  std::cout << "you have triggered a bug in Factor. Please report."
-            << std::endl;
+  cout << "The die word was called by the library. Unless you called it "
+      "yourself," << endl;
+  cout << "you have triggered a bug in Factor. Please report."
+       << endl;
   factorbug();
 }
 

--- a/vm/errors.cpp
+++ b/vm/errors.cpp
@@ -32,7 +32,7 @@ void critical_error(const char* msg, cell tagged) {
 
 void out_of_memory(const char *msg) {
   std::cout << "Out of memory: " << msg << "\n\n";
-  current_vm()->dump_generations();
+  current_vm()->dump_generations(std::cout);
   abort();
 }
 
@@ -80,10 +80,10 @@ void factor_vm::general_error(vm_error_type error, cell arg1_, cell arg2_) {
     std::cout << "You have triggered a bug in Factor. Please report.\n";
     std::cout << "error: " << error << std::endl;
     std::cout << "arg 1: ";
-    print_obj(arg1.value());
+    print_obj(std::cout, arg1.value());
     std::cout << std::endl;
     std::cout << "arg 2: ";
-    print_obj(arg2.value());
+    print_obj(std::cout, arg2.value());
     std::cout << std::endl;
     factorbug();
     abort();

--- a/vm/master.hpp
+++ b/vm/master.hpp
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <iomanip>
 #include <limits>
+#include <sstream>
 #include <string>
 
 #define FACTOR_STRINGIZE_I(x) #x

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -576,6 +576,10 @@ struct factor_vm {
 #endif
   cell compute_vm_address(cell arg);
   void store_external_address(instruction_operand op);
+  cell lookup_external_address(relocation_type rel_type,
+                               code_block* compiled,
+                               array* parameters,
+                               cell index);
   cell compute_here_address(cell arg, cell offset, code_block* compiled);
   void initialize_code_block(code_block* compiled, cell literals);
   void initialize_code_block(code_block* compiled);

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -1,3 +1,5 @@
+using namespace std;
+
 namespace factor {
 
 struct growable_array;
@@ -389,29 +391,29 @@ struct factor_vm {
   template <typename Array> Array* reallot_array(Array* array_, cell capacity);
 
   // debug
-  void print_chars(string* str);
-  void print_word(word* word, cell nesting);
-  void print_factor_string(string* str);
-  void print_array(array* array, cell nesting);
-  void print_byte_array(byte_array* array, cell nesting);
-  void print_tuple(tuple* tuple, cell nesting);
-  void print_alien(alien* alien, cell nesting);
-  void print_nested_obj(cell obj, fixnum nesting);
-  void print_obj(cell obj);
-  void print_objects(cell* start, cell* end);
-  void print_datastack();
-  void print_retainstack();
-  void print_callstack();
-  void print_callstack_object(callstack* obj);
-  void dump_cell(cell x);
-  void dump_memory(cell from, cell to);
+  void print_chars(ostream& out, string* str);
+  void print_word(ostream& out, word* word, cell nesting);
+  void print_factor_string(ostream& out, string* str);
+  void print_array(ostream& out, array* array, cell nesting);
+  void print_byte_array(ostream& out, byte_array* array, cell nesting);
+  void print_tuple(ostream& out, tuple* tuple, cell nesting);
+  void print_alien(ostream& out, alien* alien, cell nesting);
+  void print_nested_obj(ostream& out, cell obj, fixnum nesting);
+  void print_obj(ostream& out, cell obj);
+  void print_objects(ostream& out, cell* start, cell* end);
+  void print_datastack(ostream& out);
+  void print_retainstack(ostream& out);
+  void print_callstack(ostream& out);
+  void print_callstack_object(ostream& out, callstack* obj);
+  void dump_cell(ostream& out, cell x);
+  void dump_memory(ostream& out, cell from, cell to);
   template <typename Generation>
-  void dump_generation(const char* name, Generation* gen);
-  void dump_generations();
-  void dump_objects(cell type);
-  void dump_edges();
-  void find_data_references(cell look_for_);
-  void dump_code_heap();
+  void dump_generation(ostream& out, const char* name, Generation* gen);
+  void dump_generations(ostream& out);
+  void dump_objects(ostream& out, cell type);
+  void dump_edges(ostream& out);
+  void find_data_references(ostream& out, cell look_for_);
+  void dump_code_heap(ostream& out);
   void factorbug_usage(bool advanced_p);
   void factorbug();
   void primitive_die();


### PR DESCRIPTION
I noticed that the build bot fails with the error `critical_error: Bad symbol specifier in compute_dlsym_address: b5e437d7` so this pr tries to improve on that by making the error message better.

The first (big) commit adds an `ostream& out` printing methods because that makes them easier to use when building error message. The second refactors `store_external_address` in such a way so that it outpus the name of the word that caused the bad symbol specifier error which should make it easier to debug. E.g `critical_error: unix.ffi:getservbyport: Bad symbol specifier in store_external_address: 7f88469c9a39`