### PR TITLE
Gc fixes afl

### DIFF
--- a/vm/aging_collector.cpp
+++ b/vm/aging_collector.cpp
@@ -16,7 +16,7 @@ void factor_vm::collect_aging() {
 
     if (event)
       event->started_card_scan();
-    collector.trace_cards(data->tenured, card_points_to_aging, full_unmarker());
+    collector.trace_cards(data->tenured, card_points_to_aging, 0xff);
     if (event)
       event->ended_card_scan(collector.cards_scanned, collector.decks_scanned);
 

--- a/vm/aging_collector.cpp
+++ b/vm/aging_collector.cpp
@@ -38,9 +38,8 @@ void factor_vm::collect_aging() {
     copying_collector<aging_space, aging_policy> collector(this,
                                                            this->data->aging,
                                                            aging_policy(this));
-    collector.data_visitor.visit_roots();
-    collector.data_visitor.visit_contexts();
 
+    collector.visitor.visit_all_roots();
     collector.cheneys_algorithm();
 
     data->reset_nursery();

--- a/vm/aging_collector.cpp
+++ b/vm/aging_collector.cpp
@@ -26,7 +26,7 @@ void factor_vm::collect_aging() {
     if (event)
       event->ended_code_scan(collector.code_blocks_scanned);
 
-    collector.tenure_reachable_objects();
+    collector.visitor.visit_mark_stack(&mark_stack);
   }
   {
     /* If collection fails here, do a to_tenured collection. */

--- a/vm/callstack.hpp
+++ b/vm/callstack.hpp
@@ -44,10 +44,13 @@ template <typename Iterator, typename Fixup>
 void factor_vm::iterate_callstack(context* ctx, Iterator& iterator,
                                   Fixup& fixup) {
 
-  FACTOR_ASSERT(!Fixup::translated_code_block_map);
   cell top = ctx->callstack_top;
+  cell bottom = ctx->callstack_bottom;
+  /* When we are translating the code block maps, all callstacks must
+     be empty. */
+  FACTOR_ASSERT(!Fixup::translated_code_block_map || top == bottom);
 
-  while (top < ctx->callstack_bottom) {
+  while (top < bottom) {
     cell addr = *(cell*)top;
     FACTOR_ASSERT(addr != 0);
 
@@ -65,7 +68,7 @@ void factor_vm::iterate_callstack(context* ctx, Iterator& iterator,
     iterator(top, size, owner, addr);
     top += size;
   }
-  FACTOR_ASSERT(top == ctx->callstack_bottom);
+  FACTOR_ASSERT(top == bottom);
 }
 
 /* Allocates memory */

--- a/vm/collector.hpp
+++ b/vm/collector.hpp
@@ -99,18 +99,6 @@ template <typename TargetGeneration, typename Policy> struct collector {
     }
   }
 
-  cell first_card_in_deck(cell deck) {
-    return deck << (deck_bits - card_bits);
-  }
-
-  cell last_card_in_deck(cell deck) {
-    return first_card_in_deck(deck + 1);
-  }
-
-  cell card_deck_for_address(cell a) {
-    return addr_to_deck(a - data->start);
-  }
-
   void trace_partial_objects(cell start, cell card_start, cell card_end) {
     object* obj = (object*)start;
     cell end = start + obj->binary_payload_start();
@@ -160,8 +148,8 @@ template <typename TargetGeneration, typename Policy> struct collector {
     card_deck* decks = data->decks;
     card_deck* cards = data->cards;
 
-    cell first_deck = card_deck_for_address(gen->start);
-    cell last_deck = card_deck_for_address(gen->end);
+    cell first_deck = (gen->start - data->start) / deck_size;
+    cell last_deck = (gen->end - data->start) / deck_size;
 
     /* Address of last traced object. */
     cell start = 0;
@@ -171,8 +159,8 @@ template <typename TargetGeneration, typename Policy> struct collector {
         decks[deck_index] &= ~unmask;
         decks_scanned++;
 
-        cell first_card = first_card_in_deck(deck_index);
-        cell last_card = last_card_in_deck(deck_index);
+        cell first_card = cards_per_deck * deck_index;
+        cell last_card = first_card + cards_per_deck;
 
         for (cell card_index = first_card; card_index < last_card;
              card_index++) {

--- a/vm/collector.hpp
+++ b/vm/collector.hpp
@@ -79,7 +79,7 @@ template <typename TargetGeneration, typename Policy> struct collector {
   code_heap* code;
   TargetGeneration* target;
   gc_workhorse<TargetGeneration, Policy> workhorse;
-  slot_visitor<gc_workhorse<TargetGeneration, Policy> > data_visitor;
+  slot_visitor<gc_workhorse<TargetGeneration, Policy> > visitor;
   cell cards_scanned;
   cell decks_scanned;
   cell code_blocks_scanned;
@@ -90,13 +90,13 @@ template <typename TargetGeneration, typename Policy> struct collector {
         code(parent->code),
         target(target),
         workhorse(parent, target, policy),
-        data_visitor(parent, workhorse),
+        visitor(parent, workhorse),
         cards_scanned(0),
         decks_scanned(0),
         code_blocks_scanned(0) {}
 
   void trace_object(object* ptr) {
-    data_visitor.visit_slots(ptr);
+    visitor.visit_slots(ptr);
     if (ptr->type() == ALIEN_TYPE)
       ((alien*)ptr)->update_address();
   }
@@ -107,8 +107,8 @@ template <typename TargetGeneration, typename Policy> struct collector {
 
     for (; iter != end; iter++) {
       code_block* compiled = *iter;
-      data_visitor.visit_code_block_objects(compiled);
-      data_visitor.visit_embedded_literals(compiled);
+      visitor.visit_code_block_objects(compiled);
+      visitor.visit_embedded_literals(compiled);
       compiled->flush_icache();
       code_blocks_scanned++;
     }
@@ -148,7 +148,7 @@ template <typename TargetGeneration, typename Policy> struct collector {
       cell* end_ptr = (cell*)end;
 
       for (; slot_ptr < end_ptr; slot_ptr++)
-        data_visitor.visit_handle(slot_ptr);
+        visitor.visit_handle(slot_ptr);
     }
   }
 

--- a/vm/compaction.cpp
+++ b/vm/compaction.cpp
@@ -211,8 +211,7 @@ void factor_vm::collect_compact_impl() {
       code->allocator->compact(code_block_updater, fixup, &code_finger);
     }
 
-    forwarder.visit_roots();
-    forwarder.visit_contexts();
+    forwarder.visit_all_roots();
     forwarder.visit_context_code_blocks();
   }
 

--- a/vm/contexts.cpp
+++ b/vm/contexts.cpp
@@ -174,26 +174,22 @@ void factor_vm::primitive_context_object_for() {
 }
 
 /* Allocates memory */
-cell factor_vm::stack_to_array(cell bottom, cell top) {
+cell factor_vm::stack_to_array(cell bottom, cell top, vm_error_type error) {
   fixnum depth = (fixnum)(top - bottom + sizeof(cell));
 
-  if (depth < 0)
-    return false_object;
-  else {
-    array* a = allot_uninitialized_array<array>(depth / sizeof(cell));
-    memcpy(a + 1, (void*)bottom, depth);
-    return tag<array>(a);
+  if (depth < 0) {
+    general_error(error, false_object, false_object);
   }
+  array* a = allot_uninitialized_array<array>(depth / sizeof(cell));
+  memcpy(a + 1, (void*)bottom, depth);
+  return tag<array>(a);
 }
 
 /* Allocates memory */
 cell factor_vm::datastack_to_array(context* ctx) {
-  cell array = stack_to_array(ctx->datastack_seg->start, ctx->datastack);
-  if (array == false_object) {
-    general_error(ERROR_DATASTACK_UNDERFLOW, false_object, false_object);
-    return false_object;
-  } else
-    return array;
+  return stack_to_array(ctx->datastack_seg->start,
+                        ctx->datastack,
+                        ERROR_DATASTACK_UNDERFLOW);
 }
 
 /* Allocates memory */
@@ -207,12 +203,9 @@ void factor_vm::primitive_datastack_for() {
 
 /* Allocates memory */
 cell factor_vm::retainstack_to_array(context* ctx) {
-  cell array = stack_to_array(ctx->retainstack_seg->start, ctx->retainstack);
-  if (array == false_object) {
-    general_error(ERROR_RETAINSTACK_UNDERFLOW, false_object, false_object);
-    return false_object;
-  } else
-    return array;
+  return stack_to_array(ctx->retainstack_seg->start,
+                        ctx->retainstack,
+                        ERROR_RETAINSTACK_UNDERFLOW);
 }
 
 /* Allocates memory */

--- a/vm/copying_collector.hpp
+++ b/vm/copying_collector.hpp
@@ -11,7 +11,7 @@ struct copying_collector : collector<TargetGeneration, Policy> {
 
   void cheneys_algorithm() {
     while (scan && scan < this->target->here) {
-      this->trace_object((object*)scan);
+      this->visitor.visit_object((object*)scan);
       scan = this->target->next_object_after(scan);
     }
   }

--- a/vm/data_heap.cpp
+++ b/vm/data_heap.cpp
@@ -23,12 +23,12 @@ data_heap::data_heap(bump_allocator* vm_nursery,
   cell total_size = young_size + 2 * aging_size + tenured_size + deck_size;
   seg = new segment(total_size, false);
 
-  cell cards_size = addr_to_card(total_size);
+  cell cards_size = total_size / card_size;
   cards = new card[cards_size];
   cards_end = cards + cards_size;
   memset(cards, 0, cards_size);
 
-  cell decks_size = addr_to_deck(total_size);
+  cell decks_size = total_size / deck_size;
   decks = new card_deck[decks_size];
   decks_end = decks + decks_size;
   memset(decks, 0, decks_size);
@@ -102,8 +102,8 @@ bool data_heap::low_memory_p() {
 }
 
 void data_heap::mark_all_cards() {
-  memset(cards, -1, cards_end - cards);
-  memset(decks, -1, decks_end - decks);
+  memset(cards, 0xff, cards_end - cards);
+  memset(decks, 0xff, decks_end - decks);
 }
 
 void factor_vm::set_data_heap(data_heap* data_) {

--- a/vm/full_collector.cpp
+++ b/vm/full_collector.cpp
@@ -32,8 +32,7 @@ void factor_vm::collect_mark_impl() {
   code->allocator->state.clear_mark_bits();
   data->tenured->state.clear_mark_bits();
 
-  visitor.visit_roots();
-  visitor.visit_contexts();
+  visitor.visit_all_roots();
   visitor.visit_context_code_blocks();
   visitor.visit_uninitialized_code_blocks();
 

--- a/vm/full_collector.cpp
+++ b/vm/full_collector.cpp
@@ -36,23 +36,8 @@ void factor_vm::collect_mark_impl() {
   visitor.visit_context_code_blocks();
   visitor.visit_uninitialized_code_blocks();
 
-  while (!mark_stack.empty()) {
-    cell ptr = mark_stack.back();
-    mark_stack.pop_back();
+  visitor.visit_mark_stack(&mark_stack);
 
-    if (ptr & 1) {
-      code_block* compiled = (code_block*)(ptr - 1);
-      visitor.visit_code_block_objects(compiled);
-      visitor.visit_embedded_literals(compiled);
-      visitor.visit_embedded_code_pointers(compiled);
-    } else {
-      object* obj = (object*)ptr;
-      visitor.visit_slots(obj);
-      if (obj->type() == ALIEN_TYPE)
-        ((alien*)obj)->update_address();
-      visitor.visit_object_code_block(obj);
-    }
-  }
   data->reset_tenured();
   data->reset_aging();
   data->reset_nursery();

--- a/vm/image.cpp
+++ b/vm/image.cpp
@@ -117,8 +117,8 @@ struct start_object_updater {
 
 void factor_vm::fixup_data(cell data_offset, cell code_offset) {
   startup_fixup fixup(data_offset, code_offset);
-  slot_visitor<startup_fixup> data_workhorse(this, fixup);
-  data_workhorse.visit_roots();
+  slot_visitor<startup_fixup> visitor(this, fixup);
+  visitor.visit_all_roots();
 
   start_object_updater updater(this, fixup);
   data->tenured->iterate(updater, fixup);

--- a/vm/image.cpp
+++ b/vm/image.cpp
@@ -127,13 +127,13 @@ void factor_vm::fixup_data(cell data_offset, cell code_offset) {
 struct startup_code_block_relocation_visitor {
   factor_vm* parent;
   startup_fixup fixup;
-  slot_visitor<startup_fixup> data_visitor;
+  slot_visitor<startup_fixup> visitor;
 
   startup_code_block_relocation_visitor(factor_vm* parent,
                                         startup_fixup fixup)
       : parent(parent),
         fixup(fixup),
-        data_visitor(slot_visitor<startup_fixup>(parent, fixup)) {}
+        visitor(slot_visitor<startup_fixup>(parent, fixup)) {}
 
   void operator()(instruction_operand op) {
     code_block* compiled = op.compiled;
@@ -177,8 +177,8 @@ struct startup_code_block_updater {
       : parent(parent), fixup(fixup) {}
 
   void operator()(code_block* compiled, cell size) {
-    slot_visitor<startup_fixup> data_visitor(parent, fixup);
-    data_visitor.visit_code_block_objects(compiled);
+    slot_visitor<startup_fixup> visitor(parent, fixup);
+    visitor.visit_code_block_objects(compiled);
 
     startup_code_block_relocation_visitor code_visitor(parent, fixup);
     compiled->each_instruction_operand(code_visitor);

--- a/vm/nursery_collector.cpp
+++ b/vm/nursery_collector.cpp
@@ -9,9 +9,7 @@ void factor_vm::collect_nursery() {
                                                            this->data->aging,
                                                            nursery_policy(this));
 
-  collector.data_visitor.visit_roots();
-  collector.data_visitor.visit_contexts();
-
+  collector.visitor.visit_all_roots();
   gc_event* event = current_gc->event;
 
   if (event)

--- a/vm/nursery_collector.cpp
+++ b/vm/nursery_collector.cpp
@@ -15,8 +15,8 @@ void factor_vm::collect_nursery() {
   if (event)
     event->started_card_scan();
   collector.trace_cards(data->tenured, card_points_to_nursery,
-                        simple_unmarker(card_points_to_nursery));
-  collector.trace_cards(data->aging, card_points_to_nursery, full_unmarker());
+                        card_points_to_nursery);
+  collector.trace_cards(data->aging, card_points_to_nursery, 0xff);
 
   if (event)
     event->ended_card_scan(collector.cards_scanned, collector.decks_scanned);

--- a/vm/object_start_map.cpp
+++ b/vm/object_start_map.cpp
@@ -4,16 +4,13 @@ namespace factor {
 
 object_start_map::object_start_map(cell size, cell start)
     : size(size), start(start) {
-  object_start_offsets = new card[addr_to_card(size)];
-  object_start_offsets_end = object_start_offsets + addr_to_card(size);
+  cell card_count = size / card_size;
+  object_start_offsets = new card[card_count];
+  object_start_offsets_end = object_start_offsets + card_count;
   clear_object_start_offsets();
 }
 
 object_start_map::~object_start_map() { delete[] object_start_offsets; }
-
-cell object_start_map::first_object_in_card(cell card_index) {
-  return object_start_offsets[card_index];
-}
 
 cell object_start_map::find_object_containing_card(cell card_index) {
   if (card_index == 0)
@@ -21,13 +18,12 @@ cell object_start_map::find_object_containing_card(cell card_index) {
   else {
     card_index--;
 
-    while (first_object_in_card(card_index) == card_starts_inside_object) {
+    while (object_start_offsets[card_index] == card_starts_inside_object) {
       /* First card should start with an object */
       FACTOR_ASSERT(card_index > 0);
       card_index--;
     }
-
-    return start + (card_index << card_bits) + first_object_in_card(card_index);
+    return start + card_index * card_size + object_start_offsets[card_index];
   }
 }
 

--- a/vm/object_start_map.hpp
+++ b/vm/object_start_map.hpp
@@ -10,7 +10,6 @@ struct object_start_map {
   object_start_map(cell size, cell start);
   ~object_start_map();
 
-  cell first_object_in_card(cell card_index);
   cell find_object_containing_card(cell card_index);
   void record_object_start_offset(object* obj);
   void clear_object_start_offsets();

--- a/vm/objects.cpp
+++ b/vm/objects.cpp
@@ -88,24 +88,23 @@ struct slot_become_fixup : no_fixup {
 };
 
 struct object_become_visitor {
-  slot_visitor<slot_become_fixup>* workhorse;
+  slot_visitor<slot_become_fixup>* visitor;
 
-  explicit object_become_visitor(slot_visitor<slot_become_fixup>* workhorse)
-      : workhorse(workhorse) {}
+  explicit object_become_visitor(slot_visitor<slot_become_fixup>* visitor)
+      : visitor(visitor) {}
 
-  void operator()(object* obj) { workhorse->visit_slots(obj); }
+  void operator()(object* obj) { visitor->visit_slots(obj); }
 };
 
 struct code_block_become_visitor {
-  slot_visitor<slot_become_fixup>* workhorse;
+  slot_visitor<slot_become_fixup>* visitor;
 
   explicit code_block_become_visitor(
-      slot_visitor<slot_become_fixup>* workhorse)
-      : workhorse(workhorse) {}
+      slot_visitor<slot_become_fixup>* visitor) : visitor(visitor) {}
 
   void operator()(code_block* compiled, cell size) {
-    workhorse->visit_code_block_objects(compiled);
-    workhorse->visit_embedded_literals(compiled);
+    visitor->visit_code_block_objects(compiled);
+    visitor->visit_embedded_literals(compiled);
   }
 };
 
@@ -144,14 +143,14 @@ void factor_vm::primitive_become() {
 
   /* Update all references to old objects to point to new objects */
   {
-    slot_visitor<slot_become_fixup> workhorse(this,
-                                              slot_become_fixup(&become_map));
-    workhorse.visit_all_roots();
+    slot_visitor<slot_become_fixup> visitor(this,
+                                            slot_become_fixup(&become_map));
+    visitor.visit_all_roots();
 
-    object_become_visitor object_visitor(&workhorse);
+    object_become_visitor object_visitor(&visitor);
     each_object(object_visitor);
 
-    code_block_become_visitor code_block_visitor(&workhorse);
+    code_block_become_visitor code_block_visitor(&visitor);
     each_code_block(code_block_visitor);
   }
 

--- a/vm/objects.cpp
+++ b/vm/objects.cpp
@@ -146,8 +146,7 @@ void factor_vm::primitive_become() {
   {
     slot_visitor<slot_become_fixup> workhorse(this,
                                               slot_become_fixup(&become_map));
-    workhorse.visit_roots();
-    workhorse.visit_contexts();
+    workhorse.visit_all_roots();
 
     object_become_visitor object_visitor(&workhorse);
     each_object(object_visitor);

--- a/vm/slot_visitor.hpp
+++ b/vm/slot_visitor.hpp
@@ -144,6 +144,7 @@ template <typename Fixup> struct slot_visitor {
   void visit_context_code_blocks();
   void visit_uninitialized_code_blocks();
   void visit_embedded_code_pointers(code_block* compiled);
+  void visit_object(object* obj);
   void visit_mark_stack(std::vector<cell>* mark_stack);
 };
 
@@ -536,6 +537,13 @@ void slot_visitor<Fixup>::visit_embedded_code_pointers(code_block* compiled) {
   }
 }
 
+template <typename Fixup>
+void slot_visitor<Fixup>::visit_object(object *ptr) {
+  visit_slots(ptr);
+  if (ptr->type() == ALIEN_TYPE)
+    ((alien*)ptr)->update_address();
+}
+
 /* Pops items from the mark stack and visits them until the stack is
    empty. Used when doing a full collection and when collecting to
    tenured space. */
@@ -553,9 +561,7 @@ void slot_visitor<Fixup>::visit_mark_stack(std::vector<cell>* mark_stack) {
       visit_embedded_code_pointers(compiled);
     } else {
       object* obj = (object*)ptr;
-      visit_slots(obj);
-      if (obj->type() == ALIEN_TYPE)
-        ((alien*)obj)->update_address();
+      visit_object(obj);
       visit_object_code_block(obj);
     }
   }

--- a/vm/slot_visitor.hpp
+++ b/vm/slot_visitor.hpp
@@ -101,9 +101,8 @@ them.
 This is used by GC's copying, sweep and compact phases, and the implementation
 of the become primitive.
 
-Iteration is driven by visit_*() methods. Some of them define GC roots:
-- visit_roots()
-- visit_contexts()
+Iteration is driven by visit_*() methods. Only one of them define GC roots:
+- visit_all_roots()
 
 Code block visitors iterate over sets of code blocks, applying a functor to
 each one. The functor returns a new code_block pointer, which may or may not
@@ -132,7 +131,7 @@ template <typename Fixup> struct slot_visitor {
   void visit_data_roots();
   void visit_callback_roots();
   void visit_literal_table_roots();
-  void visit_roots();
+  void visit_all_roots();
   void visit_callstack_object(callstack* stack);
   void visit_callstack(context* ctx);
   void visit_context(context *ctx);
@@ -242,7 +241,7 @@ template <typename Fixup> void slot_visitor<Fixup>::visit_sample_threads() {
   }
 }
 
-template <typename Fixup> void slot_visitor<Fixup>::visit_roots() {
+template <typename Fixup> void slot_visitor<Fixup>::visit_all_roots() {
   visit_handle(&parent->true_object);
   visit_handle(&parent->bignum_zero);
   visit_handle(&parent->bignum_pos_one);
@@ -256,6 +255,9 @@ template <typename Fixup> void slot_visitor<Fixup>::visit_roots() {
 
   visit_object_array(parent->special_objects,
                      parent->special_objects + special_object_count);
+
+
+  visit_contexts();
 }
 
 /* primitive_minor_gc() is invoked by inline GC checks, and it needs to fill in

--- a/vm/to_tenured_collector.cpp
+++ b/vm/to_tenured_collector.cpp
@@ -18,7 +18,7 @@ void factor_vm::collect_to_tenured() {
 
   if (event)
     event->started_card_scan();
-  collector.trace_cards(data->tenured, card_points_to_aging, full_unmarker());
+  collector.trace_cards(data->tenured, card_points_to_aging, 0xff);
   if (event)
     event->ended_card_scan(collector.cards_scanned, collector.decks_scanned);
 

--- a/vm/to_tenured_collector.cpp
+++ b/vm/to_tenured_collector.cpp
@@ -22,9 +22,7 @@ void factor_vm::collect_to_tenured() {
 
   mark_stack.clear();
 
-  collector.data_visitor.visit_roots();
-  collector.data_visitor.visit_contexts();
-
+  collector.visitor.visit_all_roots();
   gc_event* event = current_gc->event;
 
   if (event)

--- a/vm/to_tenured_collector.cpp
+++ b/vm/to_tenured_collector.cpp
@@ -7,15 +7,6 @@ to_tenured_collector::to_tenured_collector(factor_vm* parent)
                                                   parent->data->tenured,
                                                   to_tenured_policy(parent)) {}
 
-void to_tenured_collector::tenure_reachable_objects() {
-  std::vector<cell>* mark_stack = &parent->mark_stack;
-  while (!mark_stack->empty()) {
-    cell ptr = mark_stack->back();
-    mark_stack->pop_back();
-    this->trace_object((object*)ptr);
-  }
-}
-
 void factor_vm::collect_to_tenured() {
   /* Copy live objects from aging space to tenured space. */
   to_tenured_collector collector(this);
@@ -37,7 +28,7 @@ void factor_vm::collect_to_tenured() {
   if (event)
     event->ended_code_scan(collector.code_blocks_scanned);
 
-  collector.tenure_reachable_objects();
+  collector.visitor.visit_mark_stack(&mark_stack);
 
   data->reset_nursery();
   data->reset_aging();

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -164,7 +164,7 @@ struct factor_vm {
   void primitive_context_object();
   void primitive_context_object_for();
   void primitive_set_context_object();
-  cell stack_to_array(cell bottom, cell top);
+  cell stack_to_array(cell bottom, cell top, vm_error_type error);
   cell datastack_to_array(context* ctx);
   void primitive_datastack();
   void primitive_datastack_for();

--- a/vm/write_barrier.hpp
+++ b/vm/write_barrier.hpp
@@ -16,14 +16,16 @@ static const cell card_mark_mask =
 typedef uint8_t card;
 
 static const cell card_bits = 8;
-static const cell card_size = (1 << card_bits);
-static const cell addr_card_mask = (card_size - 1);
+static const cell card_size = 1 << card_bits;
+static const cell addr_card_mask = card_size - 1;
 
 typedef uint8_t card_deck;
 
-static const cell deck_bits = (card_bits + 10);
-static const cell deck_size = (1 << deck_bits);
-static const cell addr_deck_mask = (deck_size - 1);
+static const cell deck_bits = card_bits + 10;
+/* Number of bytes on the heap a deck addresses. Each deck as 1024
+   cards. So 256 kb. */
+static const cell deck_size = 1 << deck_bits;
+static const cell cards_per_deck = 1 << 10;
 
 inline cell addr_to_card(cell a) { return a >> card_bits; }
 


### PR DESCRIPTION
Here is a bunch of gc refactorings I've been working on. The `trace_cards` function is rewritten so that you get rid of the goto. And I've also replaced some bitshifts with easier to read multiplications and divisions. It is an optimization that doesn't make sense anymore because these days it is as fast or even faster to multiply or divide instead of bit shifting.