### PR TITLE
Gc fixes afl part5

### DIFF
--- a/basis/compiler/cfg/builder/blocks/blocks.factor
+++ b/basis/compiler/cfg/builder/blocks/blocks.factor
@@ -36,7 +36,7 @@ IN: compiler.cfg.builder.blocks
     [ out-d>> length ] [ in-d>> length ] bi - ;
 
 : emit-call-block ( word height -- )
-    dup adjust-d ##call, make-kill-block ;
+    adjust-d ##call, make-kill-block ;
 
 : emit-primitive ( node -- )
     [

--- a/basis/compiler/cfg/builder/builder-tests.factor
+++ b/basis/compiler/cfg/builder/builder-tests.factor
@@ -245,7 +245,7 @@ IN: compiler.cfg.builder.tests
 
 ! emit-call
 {
-    V{ T{ ##call { word print } { height 4 } } T{ ##branch } }
+    V{ T{ ##call { word print } } T{ ##branch } }
 } [
     [ \ print 4 emit-call ] V{ } make drop
     basic-block get successors>> first instructions>>

--- a/basis/compiler/cfg/instructions/instructions-docs.factor
+++ b/basis/compiler/cfg/instructions/instructions-docs.factor
@@ -42,6 +42,9 @@ HELP: ##box-alien
 HELP: ##call
 { $class-description
   "An instruction for calling a Factor word."
+  { $table
+    { { $slot "word" } { "The word called." } }
+  }
 } ;
 
 HELP: ##check-nursery-branch
@@ -144,13 +147,13 @@ HELP: ##reload
 { $class-description "Instruction that copies a value from a " { $link spill-slot } " to a register." } ;
 
 HELP: ##replace
-{ $class-description
-  "Copies a value from a machine register to a stack location." }
-  { $see-also ##peek ##replace-imm } ;
+{ $class-description "Copies a value from a machine register to a stack location." }
+{ $see-also ##peek ##replace-imm } ;
 
 HELP: ##replace-imm
-{ $class-description
-  "An instruction that replaces an item on the data or register stack with an " { $link immediate } " value." } ;
+{ $class-description "An instruction that replaces an item on the data or register stack with an " { $link immediate } " value. The " { $link value-numbering } " compiler optimization pass can sometimes rewrite " { $link ##replace } " instructions to ##replace-imm's." }
+{ $see-also ##replace } ;
+
 
 HELP: ##return
 { $class-description "Instruction that returns from a procedure call." } ;

--- a/basis/compiler/cfg/instructions/instructions.factor
+++ b/basis/compiler/cfg/instructions/instructions.factor
@@ -57,6 +57,9 @@ literal: loc ;
 INSN: ##replace-imm
 literal: src loc ;
 
+INSN: ##clear
+literal: loc ;
+
 INSN: ##inc
 literal: loc ;
 

--- a/basis/compiler/cfg/instructions/instructions.factor
+++ b/basis/compiler/cfg/instructions/instructions.factor
@@ -62,7 +62,7 @@ literal: loc ;
 
 ! Subroutine calls
 INSN: ##call
-literal: word height ;
+literal: word ;
 
 INSN: ##jump
 literal: word ;

--- a/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
@@ -7,8 +7,8 @@ IN: compiler.cfg.stacks.clearing.tests
 {
     V{
         T{ ##inc { loc D 2 } { insn# 0 } }
-        T{ ##replace-imm { src 17 } { loc T{ ds-loc { n 1 } } } }
-        T{ ##replace-imm { src 17 } { loc T{ ds-loc } } }
+        T{ ##replace-imm { src 297 } { loc T{ ds-loc { n 1 } } } }
+        T{ ##replace-imm { src 297 } { loc T{ ds-loc } } }
         T{ ##peek { loc D 2 } { insn# 1 } }
     }
 } [
@@ -17,20 +17,28 @@ IN: compiler.cfg.stacks.clearing.tests
 ] unit-test
 
 ! dangerous-insn?
-{ t f f } [
+{
+    t f t
+} [
     { { 0 { } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-insn?
-    { { 1 { 0 } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-insn?
-    { { 0 { -1 } } { 0 { } } } T{ ##peek { loc D -1 } } dangerous-insn?
+    { { 1 { } } { 0 { } } } T{ ##peek { loc D 0 } } dangerous-insn?
+    { { 2 { 0 1 } } { 0 { } } } T{ ##peek { loc D 2 } } dangerous-insn?
 ] unit-test
 
 ! state>replaces
 {
-    {
-        T{ ##replace-imm { src 17 } { loc D 1 } }
-        T{ ##replace-imm { src 17 } { loc D 0 } }
-    }
+    { }
 } [
     { { 2 { } } { 0 { } } } state>replaces
+] unit-test
+
+{
+    {
+        T{ ##replace-imm { src 297 } { loc D 1 } }
+        T{ ##replace-imm { src 297 } { loc D 0 } }
+    }
+} [
+    { { 2 { 0 1 } } { 0 { } } } state>replaces
 ] unit-test
 
 { { } } [
@@ -39,9 +47,9 @@ IN: compiler.cfg.stacks.clearing.tests
 
 {
     {
-        T{ ##replace-imm { src 17 } { loc T{ ds-loc } } }
-        T{ ##replace-imm { src 17 } { loc T{ rs-loc } } }
+        T{ ##replace-imm { src 297 } { loc T{ ds-loc } } }
+        T{ ##replace-imm { src 297 } { loc T{ rs-loc } } }
     }
 } [
-    { { 1 { } } { 1 { } } } state>replaces
+    { { 1 { 0 } } { 1 { 0 } } } state>replaces
 ] unit-test

--- a/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing-tests.factor
@@ -7,8 +7,8 @@ IN: compiler.cfg.stacks.clearing.tests
 {
     V{
         T{ ##inc { loc D 2 } { insn# 0 } }
-        T{ ##replace-imm { src 297 } { loc T{ ds-loc { n 1 } } } }
-        T{ ##replace-imm { src 297 } { loc T{ ds-loc } } }
+        T{ ##clear { loc T{ ds-loc { n 1 } } } }
+        T{ ##clear { loc T{ ds-loc } } }
         T{ ##peek { loc D 2 } { insn# 1 } }
     }
 } [

--- a/basis/compiler/cfg/stacks/clearing/clearing.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing.factor
@@ -3,22 +3,20 @@ compiler.cfg.instructions compiler.cfg.registers compiler.cfg.rpo
 compiler.cfg.stacks compiler.cfg.stacks.padding kernel math sequences ;
 IN: compiler.cfg.stacks.clearing
 
-! This step maybe is redundant.
-
-: state>replaces ( state -- replaces )
+: state>clears ( state -- clears )
     [ second ] map { ds-loc rs-loc } [ swap create-locs ] 2map concat
-    [ 297 swap f ##replace-imm boa ] map ;
+    [ f ##clear boa ] map ;
 
 : dangerous-insn? ( state insn -- ? )
     { [ nip ##peek? ] [ underflowable-peek? ] } 2&& ;
 
-: clearing-replaces ( assoc insn -- insns' )
+: clearing-insns ( assoc insn -- insns' )
     [ insn#>> of ] keep 2dup dangerous-insn? [
-        drop state>replaces
+        drop state>clears
     ] [ 2drop { } ] if ;
 
 : visit-insns ( assoc insns -- insns' )
-    [ [ clearing-replaces ] keep suffix ] with map V{ } concat-as ;
+    [ [ clearing-insns ] keep suffix ] with map V{ } concat-as ;
 
 : clear-uninitialized ( cfg -- )
     [ trace-stack-state2 ] keep [

--- a/basis/compiler/cfg/stacks/clearing/clearing.factor
+++ b/basis/compiler/cfg/stacks/clearing/clearing.factor
@@ -3,9 +3,11 @@ compiler.cfg.instructions compiler.cfg.registers compiler.cfg.rpo
 compiler.cfg.stacks compiler.cfg.stacks.padding kernel math sequences ;
 IN: compiler.cfg.stacks.clearing
 
+! This step maybe is redundant.
+
 : state>replaces ( state -- replaces )
-    [ stack>vacant ] map { ds-loc rs-loc } [ swap create-locs ] 2map concat
-    [ 17 swap f ##replace-imm boa ] map ;
+    [ second ] map { ds-loc rs-loc } [ swap create-locs ] 2map concat
+    [ 297 swap f ##replace-imm boa ] map ;
 
 : dangerous-insn? ( state insn -- ? )
     { [ nip ##peek? ] [ underflowable-peek? ] } 2&& ;

--- a/basis/compiler/cfg/stacks/padding/padding-tests.factor
+++ b/basis/compiler/cfg/stacks/padding/padding-tests.factor
@@ -58,16 +58,6 @@ IN: compiler.cfg.stacks.padding.tests
     V{ } combine-states
 ] unit-test
 
-! States can't be combined if their heights are different
-[
-    V{ { { 3 { } } { 0 { } } } { { 8 { } } { 0 { } } } } combine-states
-] [ height-mismatches? ] must-fail-with
-
-[
-    V{ { { 4 { } } { 2 { 0 1 } } } { { 5 { 4 3 2 } } { 0 { } } } }
-    combine-states
-] [ height-mismatches? ] must-fail-with
-
 ! visit-insn ##inc
 
 ! We assume that overinitialized locations are always dead.
@@ -85,36 +75,16 @@ IN: compiler.cfg.stacks.padding.tests
 
 ! visit-insn ##call
 {
-    { { 3 { } } { 0 { } } }
-} [
-    initial-state T{ ##call { height 3 } } visit-insn
-] unit-test
-
-{
-    { { -1 { } } { 0 { } } }
-} [
-    initial-state T{ ##call { height -1 } } visit-insn
-] unit-test
-
-{
-    { { 4 { } } { 0 { } } }
-} [
-    { { 2 { } } { 0 { } } } T{ ##call { height 2 } } visit-insn
-] unit-test
-
-! This looks weird but is right.
-{
     { { 0 { } } { 0 { } } }
 } [
-    { { -2 { } } { 0 { } } } T{ ##call { height 2 } } visit-insn
+    initial-state T{ ##call } visit-insn
 ] unit-test
-
 
 ! if any of the stack locations are uninitialized when ##call is
 ! visisted then something is wrong. ##call might gc and the
 ! uninitialized locations would cause a crash.
 [
-    { { 3 { 0 1 2 } } { 0 { } } } T{ ##call { height 3 } } visit-insn
+    { { 3 { 0 1 2 } } { 0 { } } } T{ ##call } visit-insn
 ] [ vacant-when-calling? ] must-fail-with
 
 ! visit-insn ##call-gc
@@ -239,7 +209,7 @@ IN: compiler.cfg.stacks.padding.tests
         }
         {
             2 V{
-                T{ ##call { word <array> } { height 0 } }
+                T{ ##call { word <array> } }
             }
         }
         {
@@ -297,7 +267,7 @@ IN: compiler.cfg.stacks.padding.tests
         { 19 { { 7 { 3 } } { 0 { } } } }
         { 20 { { 7 { } } { 0 { } } } }
         { 21 { { 4 { } } { 0 { } } } }
-        ! gc-map here
+        ! gc-map here with nothing to scrub
         { 22 { { 4 { } } { 0 { } } } }
     }
 } [
@@ -319,7 +289,7 @@ IN: compiler.cfg.stacks.padding.tests
         }
         {
             2 V{
-                T{ ##call { word <array> } { height -1 } }
+                T{ ##call { word <array> } }
             }
         }
         {
@@ -348,7 +318,7 @@ IN: compiler.cfg.stacks.padding.tests
         }
         {
             6 V{
-                T{ ##call { word f } { height 0 } }
+                T{ ##call { word f } }
             }
         }
         {
@@ -409,35 +379,35 @@ IN: compiler.cfg.stacks.padding.tests
         { 2 { { 3 { 0 1 } } { 0 { } } } }
         { 3 { { 3 { 1 } } { 0 { } } } }
         { 4 { { 3 { } } { 0 { } } } }
-        { 5 { { 2 { } } { 0 { } } } }
-        { 6 { { 2 { } } { 0 { } } } }
-        { 7 { { 2 { } } { 0 { } } } }
-        { 8 { { 3 { 0 } } { 0 { } } } }
-        { 9 { { 3 { 0 } } { 1 { 0 } } } }
-        { 10 { { 3 { 0 1 } } { 1 { } } } }
-        { 11 { { 1 { } } { 1 { } } } }
-        { 12 { { 1 { } } { 6 { 0 1 2 3 4 } } } }
-        { 13 { { 1 { } } { 6 { 0 1 2 4 } } } }
-        { 14 { { 1 { } } { 6 { 0 1 2 4 } } } }
-        { 15 { { 1 { } } { 6 { 0 1 2 } } } }
-        { 16 { { 1 { } } { 6 { 0 1 } } } }
-        { 17 { { 1 { } } { 6 { 0 } } } }
-        { 18 { { 1 { } } { 6 { } } } }
-        { 19 { { 1 { } } { 6 { } } } }
-        { 20 { { 1 { } } { 6 { } } } }
-        { 21 { { 1 { } } { 6 { } } } }
-        { 22 { { 1 { } } { 6 { } } } }
-        { 23 { { 1 { } } { 6 { } } } }
-        { 24 { { 1 { } } { 6 { } } } }
-        { 25 { { 1 { } } { 6 { } } } }
-        { 26 { { 3 { 0 1 } } { 6 { } } } }
-        { 27 { { 3 { 0 1 } } { 1 { } } } }
-        ! gc-map here
-        { 28 { { 3 { 0 1 } } { 1 { } } } }
-        { 29 { { 3 { 0 1 } } { 1 { } } } }
-        { 30 { { 0 { } } { 1 { } } } }
-        { 31 { { 1 { 0 } } { 1 { } } } }
-        { 32 { { 1 { 0 } } { 0 { } } } }
+        { 5 { { 3 { } } { 0 { } } } }
+        { 6 { { 3 { } } { 0 { } } } }
+        { 7 { { 3 { } } { 0 { } } } }
+        { 8 { { 4 { 0 } } { 0 { } } } }
+        { 9 { { 4 { 0 } } { 1 { 0 } } } }
+        { 10 { { 4 { 0 1 } } { 1 { } } } }
+        { 11 { { 2 { } } { 1 { } } } }
+        { 12 { { 2 { } } { 6 { 0 1 2 3 4 } } } }
+        { 13 { { 2 { } } { 6 { 0 1 2 4 } } } }
+        { 14 { { 2 { } } { 6 { 0 1 2 4 } } } }
+        { 15 { { 2 { } } { 6 { 0 1 2 } } } }
+        { 16 { { 2 { } } { 6 { 0 1 } } } }
+        { 17 { { 2 { } } { 6 { 0 } } } }
+        { 18 { { 2 { } } { 6 { } } } }
+        { 19 { { 2 { } } { 6 { } } } }
+        { 20 { { 2 { } } { 6 { } } } }
+        { 21 { { 2 { } } { 6 { } } } }
+        { 22 { { 2 { } } { 6 { } } } }
+        { 23 { { 2 { } } { 6 { } } } }
+        { 24 { { 2 { } } { 6 { } } } }
+        { 25 { { 2 { } } { 6 { } } } }
+        { 26 { { 4 { 0 1 } } { 6 { } } } }
+        { 27 { { 4 { 0 1 } } { 1 { } } } }
+        ! gc-map here scrubbing D 0 and D 1
+        { 28 { { 4 { 0 1 } } { 1 { } } } }
+        { 29 { { 4 { 0 1 } } { 1 { } } } }
+        { 30 { { 1 { } } { 1 { } } } }
+        { 31 { { 2 { 0 } } { 1 { } } } }
+        { 32 { { 2 { 0 } } { 0 { } } } }
     }
 } [ bug1289-cfg trace-stack-state2 ] unit-test
 
@@ -460,9 +430,9 @@ IN: compiler.cfg.stacks.padding.tests
                 T{ ##replace { loc D 0 } }
             }
         }
-        { 3 V{ T{ ##call { height -1 } } } }
+        { 3 V{ T{ ##call } } }
         { 4 V{ } }
-        { 5 V{ T{ ##call { height 0 } } } }
+        { 5 V{ T{ ##call } } }
         { 6 V{ T{ ##peek { loc D 0 } } } }
         { 7 V{ } }
         {
@@ -472,16 +442,16 @@ IN: compiler.cfg.stacks.padding.tests
                 T{ ##replace { loc D 0 } }
             }
         }
-        { 9 V{ T{ ##call { height -1 } } } }
+        { 9 V{ T{ ##call } } }
         {
             10 V{
                 T{ ##inc { loc D 1 } }
                 T{ ##replace { loc D 0 } }
             }
         }
-        { 11 V{ T{ ##call { height -1 } } } }
+        { 11 V{ T{ ##call } } }
         { 12 V{ } }
-        { 13 V{ T{ ##call { height 0 } } } }
+        { 13 V{ T{ ##call } } }
         { 14 V{ T{ ##peek { loc D 0 } } } }
         { 15 V{ } }
         {
@@ -490,7 +460,7 @@ IN: compiler.cfg.stacks.padding.tests
                 T{ ##replace { loc D 0 } }
             }
         }
-        { 17 V{ T{ ##call { height 0 } } } }
+        { 17 V{ T{ ##call } } }
         {
             18 V{
                 T{ ##peek { loc D 2 } }
@@ -507,9 +477,9 @@ IN: compiler.cfg.stacks.padding.tests
                 T{ ##replace { loc D 0 } }
             }
         }
-        { 22 V{ T{ ##call { height 0 } } } }
+        { 22 V{ T{ ##call } } }
         { 23 V{ } }
-        { 24 V{ T{ ##call { height 0 } } } }
+        { 24 V{ T{ ##call } } }
         {
             25 V{
                 T{ ##peek { loc D 0 } }
@@ -575,37 +545,37 @@ IN: compiler.cfg.stacks.padding.tests
         { 4 { { -1 { } } { 0 { } } } }
         { 5 { { -1 { } } { 0 { } } } }
         { 6 { { -1 { } } { 0 { } } } }
-        { 7 { { -2 { } } { 0 { } } } }
-        { 8 { { -1 { 0 } } { 0 { } } } }
-        { 9 { { -1 { } } { 0 { } } } }
-        { 10 { { -2 { } } { 0 { } } } }
-        { 11 { { -2 { } } { 0 { } } } }
-        { 12 { { -2 { } } { 0 { } } } }
-        { 13 { { -1 { 0 } } { 0 { } } } }
-        { 14 { { -1 { } } { 0 { } } } }
-        { 15 { { -1 { } } { 0 { } } } }
-        { 16 { { -1 { } } { 0 { } } } }
-        { 17 { { -1 { } } { 0 { } } } }
-        { 18 { { -1 { } } { 0 { } } } }
-        { 19 { { 0 { 0 1 2 } } { 0 { } } } }
-        { 20 { { -3 { } } { 0 { } } } }
-        { 21 { { -3 { } } { 0 { } } } }
-        { 22 { { -3 { } } { 0 { } } } }
-        { 23 { { -3 { } } { 0 { } } } }
-        { 24 { { -3 { } } { 0 { } } } }
-        ! gc-map here
-        { 25 { { 0 { 0 1 2 } } { 0 { } } } }
-        { 26 { { 0 { 0 1 2 } } { 0 { } } } }
-        { 27 { { -4 { } } { 0 { } } } }
-        { 28 { { -3 { 0 } } { 0 { } } } }
+        { 7 { { -1 { } } { 0 { } } } }
+        { 8 { { 0 { 0 } } { 0 { } } } }
+        { 9 { { 0 { } } { 0 { } } } }
+        { 10 { { 0 { } } { 0 { } } } }
+        { 11 { { 0 { } } { 0 { } } } }
+        { 12 { { 0 { } } { 0 { } } } }
+        { 13 { { 1 { 0 } } { 0 { } } } }
+        { 14 { { 1 { } } { 0 { } } } }
+        { 15 { { 1 { } } { 0 { } } } }
+        { 16 { { 1 { } } { 0 { } } } }
+        { 17 { { 1 { } } { 0 { } } } }
+        { 18 { { 1 { } } { 0 { } } } }
+        { 19 { { 2 { 0 1 2 } } { 0 { } } } }
+        { 20 { { -1 { } } { 0 { } } } }
+        { 21 { { -1 { } } { 0 { } } } }
+        { 22 { { -1 { } } { 0 { } } } }
+        { 23 { { -1 { } } { 0 { } } } }
+        { 24 { { -1 { } } { 0 { } } } }
+        ! gc-map here scrubbing D 0, D 1 and D 2
+        { 25 { { 2 { 0 1 2 } } { 0 { } } } }
+        { 26 { { 2 { 0 1 2 } } { 0 { } } } }
+        { 27 { { -2 { } } { 0 { } } } }
+        { 28 { { -1 { 0 } } { 0 { } } } }
         { 29 { { -1 { } } { 0 { } } } }
         { 30 { { -2 { } } { 0 { } } } }
         { 31 { { -2 { } } { 0 { } } } }
         { 32 { { -2 { } } { 0 { } } } }
         { 33 { { -1 { 0 } } { 0 { } } } }
         { 34 { { -1 { } } { 0 { } } } }
-        { 35 { { -2 { } } { 0 { } } } }
-        { 36 { { -2 { } } { 0 { } } } }
+        { 35 { { -1 { } } { 0 { } } } }
+        { 36 { { -1 { } } { 0 { } } } }
     }
 } [
     bug-benchmark-terrain-cfg trace-stack-state2
@@ -682,7 +652,7 @@ IN: compiler.cfg.stacks.padding.tests
     V{
         T{ ##replace { src 10 } { loc D 0 } }
         T{ ##inc f D -1 }
-        T{ ##call { height 0 } }
+        T{ ##call }
     } following-stack-state
 ] unit-test
 

--- a/basis/compiler/cfg/stacks/padding/padding-tests.factor
+++ b/basis/compiler/cfg/stacks/padding/padding-tests.factor
@@ -3,9 +3,10 @@ compiler.cfg.stacks.padding compiler.cfg.utilities kernel sequences sorting
 vectors tools.test ;
 IN: compiler.cfg.stacks.padding.tests
 
-! classify-read: vacant locations
-{ 2 2 2 } [
+! classify-read: initialized locations
+{ 0 0 0 } [
     { 3 { } } 2 classify-read
+    ! Negative locations aren't tracked really.
     { 0 { } } -1 classify-read
     { 3 { } } -1 classify-read
 ] unit-test
@@ -19,42 +20,36 @@ IN: compiler.cfg.stacks.padding.tests
     { 1 { 0 } } 4 classify-read
 ] unit-test
 
-! classify-read: initialized locations
-{ 0 0 0 } [
+! classify-read: vacant locations
+{ 2 2 2 } [
     { 1 { 0 } } 0 classify-read
     { 2 { 0 1 2 } } 0 classify-read
     { 0 { 0 1 2 } } 0 classify-read
 ] unit-test
 
-! fill-stack
+! all-live
 {
-    { 2 { 4 5 0 1 } }
+    { { 0 { } } { 2 { } } }
+    { { 0 { } } { 2 { } } }
 } [
-    { 2 { 4 5 } } fill-stack
+    { { 0 { } } { 2 { } } } all-live
+    { { 0 { } } { 2 { 0 } } } all-live
 ] unit-test
 
-{
-    { -1 { 3 4 } }
-} [
-    { -1 { 3 4 } } fill-stack
-] unit-test
-
-! fill-vacancies
-{
-    { { 0 { } } { 2 { 0 1 } } }
-    { { 0 { } } { 2 { 0 1 } } }
-    { { 0 { -1 -2 } } { 2 { 0 1 } } }
-} [
-    { { 0 { } } { 2 { } } } fill-vacancies
-    { { 0 { } } { 2 { 0 } } } fill-vacancies
-    { { 0 { -1 -2 } } { 2 { 0 } } } fill-vacancies
-] unit-test
-
-! combined-state
+! combine-states
 {
     { { 4 { } } { 2 { 0 1 } } }
 } [
     V{ { { 4 { } } { 2 { 0 1 } } } } combine-states
+] unit-test
+
+{
+    { { 2 { 0 1 } } { 2 { 0 1 } } }
+} [
+    V{
+        { { 2 { 0 1 } } { 2 { } } }
+        { { 2 { } } { 2 { 0 1 } } }
+    } combine-states
 ] unit-test
 
 {
@@ -73,17 +68,6 @@ IN: compiler.cfg.stacks.padding.tests
     combine-states
 ] [ height-mismatches? ] must-fail-with
 
-! stack>vacant
-{
-    { 0 1 2 }
-    { }
-    { 1 }
-} [
-    { 3 { } } stack>vacant
-    { -2 { } } stack>vacant
-    { 3 { 0 2 } } stack>vacant
-] unit-test
-
 ! visit-insn ##inc
 
 ! We assume that overinitialized locations are always dead.
@@ -93,13 +77,18 @@ IN: compiler.cfg.stacks.padding.tests
     { { 3 { 0 } } { 0 { } } } T{ ##inc { loc D -3 } } visit-insn
 ] unit-test
 
-! visit-insn ##call
 {
     { { 3 { 0 1 2 } } { 0 { } } }
 } [
-    initial-state T{ ##call { height 3 } } visit-insn
+    { { 0 { } } { 0 { } } } T{ ##inc { loc D 3 } } visit-insn
 ] unit-test
 
+! visit-insn ##call
+{
+    { { 3 { } } { 0 { } } }
+} [
+    initial-state T{ ##call { height 3 } } visit-insn
+] unit-test
 
 {
     { { -1 { } } { 0 { } } }
@@ -107,16 +96,15 @@ IN: compiler.cfg.stacks.padding.tests
     initial-state T{ ##call { height -1 } } visit-insn
 ] unit-test
 
-
 {
-    { { 4 { 2 3 0 1 } } { 0 { } } }
+    { { 4 { } } { 0 { } } }
 } [
-    { { 2 { 0 1 } } { 0 { } } } T{ ##call { height 2 } } visit-insn
+    { { 2 { } } { 0 { } } } T{ ##call { height 2 } } visit-insn
 ] unit-test
 
 ! This looks weird but is right.
 {
-    { { 0 { 0 1 } } { 0 { } } }
+    { { 0 { } } { 0 { } } }
 } [
     { { -2 { } } { 0 { } } } T{ ##call { height 2 } } visit-insn
 ] unit-test
@@ -126,66 +114,40 @@ IN: compiler.cfg.stacks.padding.tests
 ! visisted then something is wrong. ##call might gc and the
 ! uninitialized locations would cause a crash.
 [
-    { { 3 { } } { 0 { } } } T{ ##call { height 3 } } visit-insn
+    { { 3 { 0 1 2 } } { 0 { } } } T{ ##call { height 3 } } visit-insn
 ] [ vacant-when-calling? ] must-fail-with
-
-! ! Overinitialized locations can't be live when ##call is visited. They
-! ! could be garbage collected in the called word so they maybe wouldn't
-! ! survive.
-! [
-!     { { 0 { -1 -2 } } { 0 { -1 -2 } } } T{ ##call { height 0 } } visit-insn
-! ] [ overinitialized-when-calling? ] must-fail-with
-
-! This is tricky. Normally, there should be no overinitialized
-! locations before a ##call (I think). But if they are, we can at
-! least be sure they are dead after the call.
-{
-    { { 2 { 0 1 } } { 0 { } } }
-} [
-    { { 2 { 0 1 -1 } } { 0 { } } } T{ ##call { height 0 } } visit-insn
-] unit-test
 
 ! visit-insn ##call-gc
 
-! ##call-gc ofcourse fills all uninitialized locations.
+! ##call-gc ofcourse fills all uninitialized locations. ##peek still
+! shouldn't look at them, but if we gc again we don't need to exept ##them.
 {
-    { { 4 { 0 1 2 3 } } { 0 { } } }
+    { { 4 { } } { 0 { } } }
 } [
-    { { 4 { } } { 0 { } } } T{ ##call-gc } visit-insn
+    { { 4 { 0 1 2 3 } } { 0 { } } } T{ ##call-gc } visit-insn
 ] unit-test
-
-
-[
-    { { 2 { -1 0 1 } } { 0 { } } } T{ ##call-gc } visit-insn
-] [ overinitialized-when-gc? ] must-fail-with
 
 ! visit-insn ##peek
 {
     { { 3 { 0 } } { 0 { } } }
 } [
-    { { 3 { 0 } } { 0 { } } } T{ ##peek { dst 1 } { loc D 0 } } visit-insn
+    { { 3 { 0 } } { 0 { } } } T{ ##peek { dst 1 } { loc D 1 } } visit-insn
 ] unit-test
 
 ! After a ##peek that can cause a stack underflow, it is certain that
 ! all stack locations are initialized.
 {
-    { { 0 { } } { 2 { 0 1 2 } } }
-    { { 2 { 0 1 2 } } { 0 { } } }
+    { { 0 { } } { 2 { } } }
+    { { 2 { } } { 0 { } } }
 } [
-    { { 0 { } } { 2 { } } } T{ ##peek { dst 1 } { loc R 2 } } visit-insn
-    { { 2 { } } { 0 { } } } T{ ##peek { dst 1 } { loc D 2 } } visit-insn
-] unit-test
-
-{
-    { { 2 { 0 1 } } { 2 { 0 1 2 } } }
-} [
-    { { 2 { } } { 2 { } } } T{ ##peek { dst 1 } { loc R 2 } } visit-insn
+    { { 0 { } } { 2 { 0 1 } } } T{ ##peek { dst 1 } { loc R 2 } } visit-insn
+    { { 2 { 0 1 } } { 0 { } } } T{ ##peek { dst 1 } { loc D 2 } } visit-insn
 ] unit-test
 
 ! If the ##peek can't cause a stack underflow, then we don't have the
 ! same guarantees.
 [
-    { { 3 { } } { 0 { } } } T{ ##peek { dst 1 } { loc D 0 } } visit-insn
+    { { 3 { 0 1 2 } } { 0 { } } } T{ ##peek { dst 1 } { loc D 0 } } visit-insn
 ] [ vacant-peek? ] must-fail-with
 
 : following-stack-state ( insns -- state )
@@ -201,11 +163,11 @@ IN: compiler.cfg.stacks.padding.tests
         }
         {
             1
-            { { 2 { } } { 0 { } } }
+            { { 2 { 0 1 } } { 0 { } } }
         }
         {
             2
-            { { 2 { 0 1 2 } } { 0 { } } }
+            { { 2 { } } { 0 { } } }
         }
     }
 } [
@@ -231,29 +193,13 @@ IN: compiler.cfg.stacks.padding.tests
 {
     H{
         { 0 { { 0 { } } { 0 { } } } }
-        { 1 { { 3 { } } { 0 { } } } }
-        { 2 { { 3 { 0 1 2 3 } } { 0 { } } } }
+        { 1 { { 3 { 0 1 2 } } { 0 { } } } }
+        { 2 { { 3 { } } { 0 { } } } }
     }
 } [
     V{
         T{ ##inc f D 3 }
         T{ ##peek { loc D 3 } }
-        T{ ##branch }
-    }
-    insns>cfg trace-stack-state2
-] unit-test
-
-! Replace -1 then peek is ok.
-{
-    H{
-        { 0 { { 0 { } } { 0 { } } } }
-        { 1 { { 0 { -1 } } { 0 { } } } }
-        { 2 { { 0 { -1 } } { 0 { } } } }
-    }
-} [
-    V{
-        T{ ##replace { src 10 } { loc D -1 } }
-        T{ ##peek { loc D -1 } }
         T{ ##branch }
     }
     insns>cfg trace-stack-state2
@@ -273,9 +219,9 @@ IN: compiler.cfg.stacks.padding.tests
 {
     H{
         { 0 { { 0 { } } { 0 { } } } }
-        { 1 { { 1 { } } { 0 { } } } }
-        { 2 { { 1 { 0 } } { 0 { } } } }
-        { 3 { { 1 { 0 } } { 0 { } } } }
+        { 1 { { 1 { 0 } } { 0 { } } } }
+        { 2 { { 1 { } } { 0 { } } } }
+        { 3 { { 1 { } } { 0 { } } } }
     }
 } [ cfg1 trace-stack-state2 ] unit-test
 
@@ -333,25 +279,26 @@ IN: compiler.cfg.stacks.padding.tests
         { 1 { { 0 { } } { 0 { } } } }
         { 2 { { 0 { } } { 0 { } } } }
         { 3 { { 0 { } } { 0 { } } } }
-        { 4 { { 2 { } } { 0 { } } } }
-        { 5 { { 2 { 1 } } { 0 { } } } }
-        { 6 { { 2 { 1 0 } } { 0 { } } } }
-        { 7 { { 2 { 1 0 } } { 0 { } } } }
-        { 8 { { 2 { 1 0 } } { 0 { } } } }
-        { 9 { { 2 { 1 0 } } { 0 { } } } }
-        { 10 { { 4 { 3 2 } } { 0 { } } } }
-        { 11 { { 4 { 3 2 } } { 0 { } } } }
-        { 12 { { 4 { 3 2 } } { 0 { } } } }
-        { 13 { { 4 { 3 2 1 } } { 0 { } } } }
-        { 14 { { 4 { 3 2 1 } } { 0 { } } } }
-        { 15 { { 4 { 3 2 1 } } { 0 { } } } }
-        { 16 { { 7 { 6 5 4 } } { 0 { } } } }
-        { 17 { { 7 { 6 5 4 0 } } { 0 { } } } }
-        { 18 { { 7 { 6 5 4 0 1 } } { 0 { } } } }
-        { 19 { { 7 { 6 5 4 0 1 2 } } { 0 { } } } }
-        { 20 { { 7 { 6 5 4 0 1 2 3 } } { 0 { } } } }
-        { 21 { { 4 { 3 2 1 0 } } { 0 { } } } }
-        { 22 { { 4 { 3 2 1 0 } } { 0 { } } } }
+        { 4 { { 2 { 0 1 } } { 0 { } } } }
+        { 5 { { 2 { 0 } } { 0 { } } } }
+        { 6 { { 2 { } } { 0 { } } } }
+        { 7 { { 2 { } } { 0 { } } } }
+        { 8 { { 2 { } } { 0 { } } } }
+        { 9 { { 2 { } } { 0 { } } } }
+        { 10 { { 4 { 0 1 } } { 0 { } } } }
+        { 11 { { 4 { 0 1 } } { 0 { } } } }
+        { 12 { { 4 { 0 1 } } { 0 { } } } }
+        { 13 { { 4 { 0 } } { 0 { } } } }
+        { 14 { { 4 { 0 } } { 0 { } } } }
+        { 15 { { 4 { 0 } } { 0 { } } } }
+        { 16 { { 7 { 3 0 1 2 } } { 0 { } } } }
+        { 17 { { 7 { 3 1 2 } } { 0 { } } } }
+        { 18 { { 7 { 3 2 } } { 0 { } } } }
+        { 19 { { 7 { 3 } } { 0 { } } } }
+        { 20 { { 7 { } } { 0 { } } } }
+        { 21 { { 4 { } } { 0 { } } } }
+        ! gc-map here
+        { 22 { { 4 { } } { 0 { } } } }
     }
 } [
     bug1021-cfg trace-stack-state2
@@ -458,40 +405,212 @@ IN: compiler.cfg.stacks.padding.tests
 {
     H{
         { 0 { { 0 { } } { 0 { } } } }
-        { 1 { { 3 { } } { 0 { } } } }
-        { 2 { { 3 { 2 } } { 0 { } } } }
-        { 3 { { 3 { 2 0 } } { 0 { } } } }
-        { 4 { { 3 { 2 0 1 } } { 0 { } } } }
-        { 5 { { 2 { 1 0 } } { 0 { } } } }
-        { 6 { { 2 { 1 0 } } { 0 { } } } }
-        { 7 { { 2 { 1 0 } } { 0 { } } } }
-        { 8 { { 3 { 2 1 } } { 0 { } } } }
-        { 9 { { 3 { 2 1 } } { 1 { } } } }
-        { 10 { { 3 { 2 } } { 1 { 0 } } } }
-        { 11 { { 1 { 0 } } { 1 { 0 } } } }
-        { 12 { { 1 { 0 } } { 6 { 5 } } } }
-        { 13 { { 1 { 0 } } { 6 { 5 3 } } } }
-        { 14 { { 1 { 0 } } { 6 { 5 3 } } } }
-        { 15 { { 1 { 0 } } { 6 { 5 3 4 } } } }
-        { 16 { { 1 { 0 } } { 6 { 5 3 4 2 } } } }
-        { 17 { { 1 { 0 } } { 6 { 5 3 4 2 1 } } } }
-        { 18 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 19 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 20 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 21 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 22 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 23 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 24 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 25 { { 1 { 0 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 26 { { 3 { 2 } } { 6 { 5 3 4 2 1 0 } } } }
-        { 27 { { 3 { 2 } } { 1 { 0 } } } }
-        { 28 { { 3 { 2 } } { 1 { 0 } } } }
-        { 29 { { 3 { 2 } } { 1 { 0 } } } }
-        { 30 { { 0 { } } { 1 { 0 } } } }
-        { 31 { { 1 { } } { 1 { 0 } } } }
-        { 32 { { 1 { } } { 0 { } } } }
+        { 1 { { 3 { 0 1 2 } } { 0 { } } } }
+        { 2 { { 3 { 0 1 } } { 0 { } } } }
+        { 3 { { 3 { 1 } } { 0 { } } } }
+        { 4 { { 3 { } } { 0 { } } } }
+        { 5 { { 2 { } } { 0 { } } } }
+        { 6 { { 2 { } } { 0 { } } } }
+        { 7 { { 2 { } } { 0 { } } } }
+        { 8 { { 3 { 0 } } { 0 { } } } }
+        { 9 { { 3 { 0 } } { 1 { 0 } } } }
+        { 10 { { 3 { 0 1 } } { 1 { } } } }
+        { 11 { { 1 { } } { 1 { } } } }
+        { 12 { { 1 { } } { 6 { 0 1 2 3 4 } } } }
+        { 13 { { 1 { } } { 6 { 0 1 2 4 } } } }
+        { 14 { { 1 { } } { 6 { 0 1 2 4 } } } }
+        { 15 { { 1 { } } { 6 { 0 1 2 } } } }
+        { 16 { { 1 { } } { 6 { 0 1 } } } }
+        { 17 { { 1 { } } { 6 { 0 } } } }
+        { 18 { { 1 { } } { 6 { } } } }
+        { 19 { { 1 { } } { 6 { } } } }
+        { 20 { { 1 { } } { 6 { } } } }
+        { 21 { { 1 { } } { 6 { } } } }
+        { 22 { { 1 { } } { 6 { } } } }
+        { 23 { { 1 { } } { 6 { } } } }
+        { 24 { { 1 { } } { 6 { } } } }
+        { 25 { { 1 { } } { 6 { } } } }
+        { 26 { { 3 { 0 1 } } { 6 { } } } }
+        { 27 { { 3 { 0 1 } } { 1 { } } } }
+        ! gc-map here
+        { 28 { { 3 { 0 1 } } { 1 { } } } }
+        { 29 { { 3 { 0 1 } } { 1 { } } } }
+        { 30 { { 0 { } } { 1 { } } } }
+        { 31 { { 1 { 0 } } { 1 { } } } }
+        { 32 { { 1 { 0 } } { 0 { } } } }
     }
 } [ bug1289-cfg trace-stack-state2 ] unit-test
+
+: bug-benchmark-terrain-cfg ( -- cfg )
+    H{
+        { 0 V{ } }
+        {
+            1 V{
+                T{ ##peek { loc D 0 } }
+                T{ ##peek { loc D 1 } }
+                T{ ##inc { loc D -1 } }
+            }
+        }
+        {
+            2 V{
+                T{ ##inc { loc D -1 } }
+                T{ ##replace { loc D 1 } }
+                T{ ##replace { loc D 0 } }
+                T{ ##inc { loc D 1 } }
+                T{ ##replace { loc D 0 } }
+            }
+        }
+        { 3 V{ T{ ##call { height -1 } } } }
+        { 4 V{ } }
+        { 5 V{ T{ ##call { height 0 } } } }
+        { 6 V{ T{ ##peek { loc D 0 } } } }
+        { 7 V{ } }
+        {
+            8 V{
+                T{ ##replace { loc D 2 } }
+                T{ ##replace { loc D 1 } }
+                T{ ##replace { loc D 0 } }
+            }
+        }
+        { 9 V{ T{ ##call { height -1 } } } }
+        {
+            10 V{
+                T{ ##inc { loc D 1 } }
+                T{ ##replace { loc D 0 } }
+            }
+        }
+        { 11 V{ T{ ##call { height -1 } } } }
+        { 12 V{ } }
+        { 13 V{ T{ ##call { height 0 } } } }
+        { 14 V{ T{ ##peek { loc D 0 } } } }
+        { 15 V{ } }
+        {
+            16 V{
+                T{ ##inc { loc D 1 } }
+                T{ ##replace { loc D 0 } }
+            }
+        }
+        { 17 V{ T{ ##call { height 0 } } } }
+        {
+            18 V{
+                T{ ##peek { loc D 2 } }
+                T{ ##peek { loc D 1 } }
+                T{ ##peek { loc D 0 } }
+                T{ ##inc { loc D 1 } }
+            }
+        }
+        { 19 V{ } }
+        { 20 V{ } }
+        {
+            21 V{
+                T{ ##inc { loc D -3 } }
+                T{ ##replace { loc D 0 } }
+            }
+        }
+        { 22 V{ T{ ##call { height 0 } } } }
+        { 23 V{ } }
+        { 24 V{ T{ ##call { height 0 } } } }
+        {
+            25 V{
+                T{ ##peek { loc D 0 } }
+                T{ ##inc { loc D 3 } }
+            }
+        }
+        { 26 V{ } }
+        { 27 V{ } }
+        { 28 V{ } }
+        { 29 V{ } }
+        { 30 V{ T{ ##call-gc } } }
+        { 31 V{ } }
+        {
+            32 V{
+                T{ ##inc { loc D -4 } }
+                T{ ##inc { loc D 1 } }
+                T{ ##replace { loc D 0 } }
+            }
+        }
+        { 33 V{ } }
+    } [ over insns>block ] assoc-map dup
+    {
+        { 0 1 }
+        { 1 2 } { 1 8 }
+        { 2 3 }
+        { 3 4 }
+        { 4 5 }
+        { 5 6 }
+        { 7 16 }
+        { 8 9 }
+        { 9 10 }
+        { 10 11 }
+        { 11 12 }
+        { 12 13 }
+        { 13 14 }
+        { 14 15 }
+        { 15 16 }
+        { 16 17 }
+        { 17 18 }
+        { 18 19 }
+        { 19 20 }
+        { 20 27 }
+        { 21 22 }
+        { 22 23 }
+        { 23 24 }
+        { 24 25 }
+        { 25 26 }
+        { 26 27 }
+        { 27 28 } { 27 32 }
+        { 28 29 } { 28 30 }
+        { 29 21 }
+        { 20 31 }
+        { 31 21 }
+        { 32 33 }
+    } make-edges 0 of block>cfg ;
+
+{
+    H{
+        { 0 { { 0 { } } { 0 { } } } }
+        { 1 { { 0 { } } { 0 { } } } }
+        { 2 { { 0 { } } { 0 { } } } }
+        { 3 { { -1 { } } { 0 { } } } }
+        { 4 { { -1 { } } { 0 { } } } }
+        { 5 { { -1 { } } { 0 { } } } }
+        { 6 { { -1 { } } { 0 { } } } }
+        { 7 { { -2 { } } { 0 { } } } }
+        { 8 { { -1 { 0 } } { 0 { } } } }
+        { 9 { { -1 { } } { 0 { } } } }
+        { 10 { { -2 { } } { 0 { } } } }
+        { 11 { { -2 { } } { 0 { } } } }
+        { 12 { { -2 { } } { 0 { } } } }
+        { 13 { { -1 { 0 } } { 0 { } } } }
+        { 14 { { -1 { } } { 0 { } } } }
+        { 15 { { -1 { } } { 0 { } } } }
+        { 16 { { -1 { } } { 0 { } } } }
+        { 17 { { -1 { } } { 0 { } } } }
+        { 18 { { -1 { } } { 0 { } } } }
+        { 19 { { 0 { 0 1 2 } } { 0 { } } } }
+        { 20 { { -3 { } } { 0 { } } } }
+        { 21 { { -3 { } } { 0 { } } } }
+        { 22 { { -3 { } } { 0 { } } } }
+        { 23 { { -3 { } } { 0 { } } } }
+        { 24 { { -3 { } } { 0 { } } } }
+        ! gc-map here
+        { 25 { { 0 { 0 1 2 } } { 0 { } } } }
+        { 26 { { 0 { 0 1 2 } } { 0 { } } } }
+        { 27 { { -4 { } } { 0 { } } } }
+        { 28 { { -3 { 0 } } { 0 { } } } }
+        { 29 { { -1 { } } { 0 { } } } }
+        { 30 { { -2 { } } { 0 { } } } }
+        { 31 { { -2 { } } { 0 { } } } }
+        { 32 { { -2 { } } { 0 { } } } }
+        { 33 { { -1 { 0 } } { 0 { } } } }
+        { 34 { { -1 { } } { 0 { } } } }
+        { 35 { { -2 { } } { 0 { } } } }
+        { 36 { { -2 { } } { 0 { } } } }
+    }
+} [
+    bug-benchmark-terrain-cfg trace-stack-state2
+] unit-test
+
 
 ! following-stack-state
 {
@@ -499,36 +618,24 @@ IN: compiler.cfg.stacks.padding.tests
 } [ V{ } following-stack-state ] unit-test
 
 {
-    { { 1 { } } { 0 { } } }
+    { { 1 { 0 } } { 0 { } } }
 } [ V{ T{ ##inc f D 1 } } following-stack-state ] unit-test
 
 {
-    { { 0 { } } { 1 { } } }
+    { { 0 { } } { 1 { 0 } } }
 } [ V{ T{ ##inc f R 1 } } following-stack-state ] unit-test
 
 ! Here the peek refers to a parameter of the word.
 {
-    { { 0 { 25 } } { 0 { } } }
+    { { 0 { } } { 0 { } } }
 } [
     V{
         T{ ##peek { loc D 25 } }
     } following-stack-state
 ] unit-test
 
-! Should be ok because the value was at 0 when the gc ran.
 {
-    { { -1 { -1 } } { 0 { } } }
-} [
-    V{
-        T{ ##replace { src 10 } { loc D 0 } }
-        T{ ##alien-invoke { gc-map T{ gc-map { scrub-d { } } } } }
-        T{ ##inc f D -1 }
-        T{ ##peek { loc D -1 } }
-    } following-stack-state
-] unit-test
-
-{
-    { { 0 { 0 1 2 } } { 0 { } } }
+    { { 0 { } } { 0 { } } }
 } [
     V{
         T{ ##replace { src 10 } { loc D 0 } }
@@ -538,7 +645,7 @@ IN: compiler.cfg.stacks.padding.tests
 ] unit-test
 
 {
-    { { 1 { 1 0 } } { 0 { } } }
+    { { 1 { } } { 0 { } } }
 } [
     V{
         T{ ##replace { src 10 } { loc D 0 } }
@@ -548,7 +655,7 @@ IN: compiler.cfg.stacks.padding.tests
 ] unit-test
 
 {
-    { { 0 { 0 } } { 0 { } } }
+    { { 0 { } } { 0 { } } }
 } [
     V{
         T{ ##replace { src 10 } { loc D 0 } }

--- a/basis/compiler/cfg/stacks/padding/padding.factor
+++ b/basis/compiler/cfg/stacks/padding/padding.factor
@@ -2,7 +2,7 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays assocs compiler.cfg.dataflow-analysis
 compiler.cfg.instructions compiler.cfg.linearization compiler.cfg.registers
-compiler.cfg.stacks.local fry grouping kernel math math.order namespaces
+compiler.cfg.stacks.local fry kernel math math.order namespaces
 sequences ;
 QUALIFIED: sets
 IN: compiler.cfg.stacks.padding
@@ -10,14 +10,12 @@ IN: compiler.cfg.stacks.padding
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! !! Stack
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-ERROR: height-mismatches seq ;
 
 : register-write ( n stack -- stack' )
     first2 swapd remove 2array ;
 
 : combine-stacks ( stacks -- stack )
-    [ [ first ] map dup all-equal? [ first ] [ height-mismatches ] if ]
-    [ [ second ] map sets:combine ] bi 2array ;
+    [ first first ] [ [ second ] map sets:combine ] bi 2array ;
 
 : classify-read ( stack n -- val )
     swap 2dup second member? [ 2drop 2 ] [ first >= [ 1 ] [ 0 ] if ] if ;
@@ -58,8 +56,7 @@ M: ##replace-imm visit-insn live-location ;
 M: ##replace visit-insn live-location ;
 
 M: ##call visit-insn ( state insn -- state' )
-    over ensure-no-vacant height>>
-    0 2array [ swap first2 [ + ] dip 2array ] 2map ;
+    drop dup ensure-no-vacant ;
 
 M: ##call-gc visit-insn ( state insn -- state' )
     drop all-live ;

--- a/basis/compiler/cfg/stacks/vacant/vacant-tests.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant-tests.factor
@@ -5,19 +5,24 @@ compiler.cfg.utilities compiler.cfg.stacks.vacant kernel math sequences sorting
 tools.test vectors ;
 IN: compiler.cfg.stacks.vacant.tests
 
+! state>gc-data
 {
     { { } { } }
 } [
-    { { 4 { 3 2 1 -3 0 -2 -1 } } { 0 { -1 } } } state>gc-data
+    { { 3 { } } { 3 { } } } state>gc-data
 ] unit-test
 
-{ { { 1 0 0 } { 0 } } } [
-    { { 3 { 0 } } { 1 { } } } state>gc-data
+{
+    { { 0 1 0 } { } }
+    { { 1 0 0 } { 0 } }
+} [
+    { { 3 { 0 2 } } { 3 { } } } state>gc-data
+    { { 3 { 1 2 } } { 3 { 0 } } } state>gc-data
 ] unit-test
 
 ! visit-insn should set the gc info.
 { { 0 0 } { } } [
-    { { 2 { } } { 0 { } } }
+    { { 2 { 0 1 } } { 0 { } } }
     T{ ##alien-invoke { gc-map T{ gc-map } } }
     [ gc-map>> set-gc-map ] keep gc-map>> [ scrub-d>> ] [ scrub-r>> ] bi
 ] unit-test

--- a/basis/compiler/cfg/stacks/vacant/vacant.factor
+++ b/basis/compiler/cfg/stacks/vacant/vacant.factor
@@ -10,7 +10,7 @@ IN: compiler.cfg.stacks.vacant
     ] if-empty ;
 
 : state>gc-data ( state -- gc-data )
-    [ stack>vacant vacant>bits ] map ;
+    [ second vacant>bits ] map ;
 
 : set-gc-map ( state gc-map -- )
     swap state>gc-data first2 -rot >>scrub-d swap >>scrub-r drop ;

--- a/basis/compiler/codegen/codegen-tests.factor
+++ b/basis/compiler/codegen/codegen-tests.factor
@@ -4,7 +4,7 @@ kernel make compiler.constants words ;
 IN: compiler.codegen.tests
 
 [ ] [ [ ] with-fixup drop ] unit-test
-[ ] [ [ \ + 0 %call ] with-fixup drop ] unit-test
+[ ] [ [ \ + %call ] with-fixup drop ] unit-test
 
 [ ] [ [ <label> dup define-label dup resolve-label %jump-label ] with-fixup drop ] unit-test
 [ ] [ [ <label> dup define-label dup resolve-label B{ 0 0 0 0 } % rc-absolute-cell label-fixup ] with-fixup drop ] unit-test

--- a/basis/compiler/codegen/codegen.factor
+++ b/basis/compiler/codegen/codegen.factor
@@ -147,6 +147,7 @@ CODEGEN: ##load-vector %load-vector
 CODEGEN: ##peek %peek
 CODEGEN: ##replace %replace
 CODEGEN: ##replace-imm %replace-imm
+CODEGEN: ##clear %clear
 CODEGEN: ##inc %inc
 CODEGEN: ##call %call
 CODEGEN: ##jump %jump

--- a/basis/cpu/architecture/architecture.factor
+++ b/basis/cpu/architecture/architecture.factor
@@ -234,7 +234,7 @@ HOOK: %replace-imm cpu ( src loc -- )
 HOOK: %inc cpu ( loc -- )
 
 HOOK: stack-frame-size cpu ( stack-frame -- n )
-HOOK: %call cpu ( word height -- )
+HOOK: %call cpu ( word -- )
 HOOK: %jump cpu ( word -- )
 HOOK: %jump-label cpu ( label -- )
 HOOK: %return cpu ( -- )

--- a/basis/cpu/architecture/architecture.factor
+++ b/basis/cpu/architecture/architecture.factor
@@ -231,6 +231,7 @@ HOOK: %load-vector cpu ( reg val rep -- )
 HOOK: %peek cpu ( vreg loc -- )
 HOOK: %replace cpu ( vreg loc -- )
 HOOK: %replace-imm cpu ( src loc -- )
+HOOK: %clear cpu ( loc -- )
 HOOK: %inc cpu ( loc -- )
 
 HOOK: stack-frame-size cpu ( stack-frame -- n )

--- a/basis/cpu/ppc/ppc.factor
+++ b/basis/cpu/ppc/ppc.factor
@@ -195,8 +195,8 @@ M: ppc stack-frame-size ( stack-frame -- i )
     factor-area-size +
     16 align ;
 
-M: ppc %call ( word height -- )
-    drop 0 BL rc-relative-ppc-3-pc rel-word-pic ;
+M: ppc %call ( word -- )
+    0 BL rc-relative-ppc-3-pc rel-word-pic ;
 
 : instrs ( n -- b ) 4 * ; inline
 
@@ -922,7 +922,7 @@ M:: ppc %check-nursery-branch ( label size cc temp1 temp2 -- )
     } case ;
 
 M: ppc %call-gc ( gc-map -- )
-    \ minor-gc 0 %call gc-map-here ;
+    \ minor-gc %call gc-map-here ;
 
 M:: ppc %prologue ( stack-size -- )
     0 MFLR

--- a/basis/cpu/ppc/ppc.factor
+++ b/basis/cpu/ppc/ppc.factor
@@ -184,6 +184,9 @@ M:: ppc %replace-imm ( src loc -- )
     } cond
     scratch-reg reg offset %store-cell ;
 
+M: ppc %clear ( loc -- )
+    297 swap %replace-imm ;
+
 ! Increment stack pointer by n cells.
 M: ppc %inc ( loc -- )
     [ ds-loc? [ ds-reg ds-reg ] [ rs-reg rs-reg ] if ] [ n>> ] bi cells ADDI ;

--- a/basis/cpu/x86/x86.factor
+++ b/basis/cpu/x86/x86.factor
@@ -90,6 +90,9 @@ M: x86 %replace-imm
         [ [ 0xffffffff MOV ] dip rc-absolute rel-literal ]
     } cond ;
 
+M: x86 %clear ( loc -- )
+    loc>operand 297 MOV ;
+
 : (%inc) ( n reg -- ) swap cells dup 0 > [ ADD ] [ neg SUB ] if ; inline
 
 M: x86 %inc ( loc -- )

--- a/basis/cpu/x86/x86.factor
+++ b/basis/cpu/x86/x86.factor
@@ -95,7 +95,7 @@ M: x86 %replace-imm
 M: x86 %inc ( loc -- )
     [ n>> ] [ ds-loc? ds-reg rs-reg ? ] bi (%inc) ;
 
-M: x86 %call ( word height -- ) drop 0 CALL rc-relative rel-word-pic ;
+M: x86 %call ( word -- ) 0 CALL rc-relative rel-word-pic ;
 
 : xt-tail-pic-offset ( -- n )
     #! See the comment in vm/cpu-x86.hpp
@@ -510,7 +510,7 @@ M: x86 gc-root-offset
     n>> spill-offset special-offset cell + cell /i ;
 
 M: x86 %call-gc ( gc-map -- )
-    \ minor-gc 0 %call
+    \ minor-gc %call
     gc-map-here ;
 
 M: x86 %alien-global ( dst symbol library -- )


### PR DESCRIPTION
Another attempt at fixing the gc maps. :) The tracing is inverted so that it now tracks the dead locations and not the live ones. It's very similar to how the original `compiler.cfg.stacks.uninitialized` worked but with stack height tracing added. There is also a new `##clear` instruction to make it easy to see where in the cfg the compiler inserts the clearing replaces. 