### PR TITLE
Locals fixing

### DIFF
--- a/basis/locals/locals.factor
+++ b/basis/locals/locals.factor
@@ -6,8 +6,8 @@ locals.errors ;
 IN: locals
 
 SYNTAX: :>
-    scan-token locals get [ :>-outside-lambda-error ] unless*
-    parse-def suffix! ;
+    in-lambda? get [ :>-outside-lambda-error ] unless
+    scan-token parse-def suffix! ;
 
 SYNTAX: [| parse-lambda append! ;
 

--- a/basis/locals/parser/parser-tests.factor
+++ b/basis/locals/parser/parser-tests.factor
@@ -1,28 +1,42 @@
 USING: accessors assocs compiler.units kernel lexer locals.backend
-locals.parser parser prettyprint sequences tools.test ;
+locals.parser namespaces parser prettyprint sequences sorting
+tools.test vocabs vocabs.parser ;
 IN: locals.parser.tests
 
-SYMBOL: dobiedoo
+<<
+! ((parse-lambda))
+{
+    "V{ 99 :> kkk kkk }"
+} [
+    [
+        "locals" use-vocab
+        { "99 :> kkk kkk ;" } <lexer> [
+            H{ } clone [ \ ; parse-until ] ((parse-lambda))
+        ] with-lexer
+    ] with-compilation-unit unparse
+] unit-test
 
 ! (::)
 {
-    dobiedoo
+    "dobiedoo"
     [ 1 load-locals 1 drop-locals ]
     ( x -- y )
 } [
     [
         { "dobiedoo ( x -- y ) ;" } <lexer> [ (::) ] with-lexer
     ] with-compilation-unit
+    [ name>> ] 2dip
 ] unit-test
 
-! ((parse-lambda))
-{
-    "V{ 99 :> kkk kkk }"
-} [
-    [ { "99 :> kkk kkk ;" } <lexer> [
-        H{ } clone [ \ ; parse-until ] ((parse-lambda)) ] with-lexer
-    ] with-compilation-unit unparse
+! parse-def
+{ "um" t } [
+    [
+        "um" parse-def
+        local>> name>>
+        manifest get qualified-vocabs>> last words>> keys "um" swap member?
+    ] with-compilation-unit
 ] unit-test
+>>
 
 ! check-local-name
 { "hello" } [
@@ -35,12 +49,6 @@ SYMBOL: dobiedoo
     nip values [ name>> ] map
 ] unit-test
 
-! parse-def
-{ "um" { "um" } } [
-    [ "um" H{ } clone [ parse-def ] keep ] with-compilation-unit
-    [ local>> name>> ] [ keys ] bi*
-] unit-test
-
 ! parse-local-defs
 { { "tok1" "tok2" } } [
     [
@@ -51,13 +59,11 @@ SYMBOL: dobiedoo
 
 ! parse-multi-def
 {
-    { "v1" "tok1" "tok2" }
+    { "tok1" "tok2" }
     { "tok1" "tok2" }
 } [
     [
-        { "tok1 tok2 )" } <lexer> [
-            H{ { "v1" t } } clone dup parse-multi-def
-        ] with-lexer
+        { "tok1 tok2 )" } <lexer> [ parse-multi-def ] with-lexer
     ] with-compilation-unit
-    [ keys ] [ locals>> [ name>> ] map ] bi*
+    [ locals>> [ name>> ] map ] [ keys ] bi*
 ] unit-test

--- a/basis/locals/parser/parser-tests.factor
+++ b/basis/locals/parser/parser-tests.factor
@@ -1,0 +1,63 @@
+USING: accessors assocs compiler.units kernel lexer locals.backend
+locals.parser parser prettyprint sequences tools.test ;
+IN: locals.parser.tests
+
+SYMBOL: dobiedoo
+
+! (::)
+{
+    dobiedoo
+    [ 1 load-locals 1 drop-locals ]
+    ( x -- y )
+} [
+    [
+        { "dobiedoo ( x -- y ) ;" } <lexer> [ (::) ] with-lexer
+    ] with-compilation-unit
+] unit-test
+
+! ((parse-lambda))
+{
+    "V{ 99 :> kkk kkk }"
+} [
+    [ { "99 :> kkk kkk ;" } <lexer> [
+        H{ } clone [ \ ; parse-until ] ((parse-lambda)) ] with-lexer
+    ] with-compilation-unit unparse
+] unit-test
+
+! check-local-name
+{ "hello" } [
+    "hello" check-local-name
+] unit-test
+
+! make-locals
+{ { "a" "b" "c" } } [
+    [ { "a" "b" "c" } make-locals ] with-compilation-unit
+    nip values [ name>> ] map
+] unit-test
+
+! parse-def
+{ "um" { "um" } } [
+    [ "um" H{ } clone [ parse-def ] keep ] with-compilation-unit
+    [ local>> name>> ] [ keys ] bi*
+] unit-test
+
+! parse-local-defs
+{ { "tok1" "tok2" } } [
+    [
+        { "tok1 tok2 |" } <lexer> [ parse-local-defs ] with-lexer
+    ] with-compilation-unit
+    nip values [ name>> ] map
+] unit-test
+
+! parse-multi-def
+{
+    { "v1" "tok1" "tok2" }
+    { "tok1" "tok2" }
+} [
+    [
+        { "tok1 tok2 )" } <lexer> [
+            H{ { "v1" t } } clone dup parse-multi-def
+        ] with-lexer
+    ] with-compilation-unit
+    [ keys ] [ locals>> [ name>> ] map ] bi*
+] unit-test

--- a/basis/locals/types/types-tests.factor
+++ b/basis/locals/types/types-tests.factor
@@ -1,0 +1,11 @@
+USING: accessors compiler.units kernel locals.types tools.test words ;
+IN: locals.types.test
+
+{ t } [
+    [ "hello" <local> ] with-compilation-unit "local?" word-prop
+] unit-test
+
+{ t "hello!" } [
+    [ "hello" <local-reader> <local-writer> ] with-compilation-unit
+    [ "local-writer?" word-prop ] [ name>> ] bi
+] unit-test

--- a/core/parser/parser-docs.factor
+++ b/core/parser/parser-docs.factor
@@ -284,6 +284,10 @@ HELP: auto-use?
 { $var-description "If set to a true value, the behavior of the parser when encountering an unknown word name is changed. If only one loaded vocabulary has a word with this name, instead of throwing an error, the parser adds the vocabulary to the search path and prints a parse note. Off by default." }
 { $notes "This feature is intended to help during development. To generate a " { $link POSTPONE: USING: } " form automatically, enable " { $link auto-use? } ", load the source file, and copy and paste the " { $link POSTPONE: USING: } " form printed by the parser back into the file, then disable " { $link auto-use? } ". See " { $link "word-search-errors" } "." } ;
 
+HELP: use-first-word?
+{ $values { "words" sequence } { "?" boolean } }
+{ $description "Checks if the first word can be used automatically without first throwing a restartable " { $link no-word-error } } ;
+
 HELP: scan-object
 { $values { "object" object } }
 { $description "Parses a literal representation of an object." }

--- a/core/parser/parser-tests.factor
+++ b/core/parser/parser-tests.factor
@@ -641,3 +641,9 @@ EXCLUDE: qualified.tests.bar => x ;
 
 [ "GENERIC: 33 ( -- )" <string-reader> "generic identifier test" parse-stream ]
 [ error>> lexer-error? ] must-fail-with
+
+{ t } [
+    t auto-use? [
+        { private? } use-first-word?
+    ] with-variable
+] unit-test

--- a/core/parser/parser.factor
+++ b/core/parser/parser.factor
@@ -36,17 +36,17 @@ SYMBOL: auto-use?
 
 : private? ( word -- ? ) vocabulary>> ".private" tail? ;
 
+: use-first-word? ( words -- ? )
+    [ length 1 = ] [ ?first dup [ private? not ] [ ] ?if ] bi and
+    auto-use? get and ;
+
 ! True branch is a singleton public word with no name conflicts
 ! False branch, singleton private words need confirmation regardless
 ! of name conflicts
 : no-word ( name -- newword )
     dup words-named ignore-forwards
-    dup [ length 1 = ]
-    [ [ f ] [ first private? not ] if-empty ] bi and
-    auto-use? get and
-    [ nip first no-word-restarted ]
-    [ <no-word-error> throw-restarts no-word-restarted ]
-    if ;
+    dup use-first-word? [ nip first ] [ <no-word-error> throw-restarts ] if
+    no-word-restarted ;
 
 : parse-word ( string -- word )
     dup search [ ] [ no-word ] ?if ;


### PR DESCRIPTION
I think this pr should fix #1340. For some reason the `locals` variable got out of sync with the words in the manifest after a restart. I didn't look at that so much because it was easier to just remove `locals` and use `manifest get qualified-vocabs>> last words>>` instead.