### PR TITLE
Fix 1345

### DIFF
--- a/basis/compiler/cfg/def-use/def-use-docs.factor
+++ b/basis/compiler/cfg/def-use/def-use-docs.factor
@@ -1,6 +1,10 @@
-USING: compiler.cfg compiler.cfg.instructions help.markup help.syntax
+USING: assocs compiler.cfg compiler.cfg.instructions help.markup help.syntax
 sequences ;
 IN: compiler.cfg.def-use
+
+HELP: compute-defs
+{ $values { "cfg" cfg } }
+{ $description "Computes a mapping from vregs to " { $link basic-block } " instances in which they are defined. The data is assigned to the " { $link defs } " dynamic variable." } ;
 
 HELP: compute-insns
 { $values { "cfg" cfg } }
@@ -17,9 +21,14 @@ HELP: defs-vregs
   }
 } ;
 
+HELP: insns
+{ $var-description { $link assoc } " mapping vreg integers to defining instructions." }
+{ $see-also compute-insns insn-of } ;
+
 HELP: insn-of
 { $values { "vreg" "virtual register" } { "insn" insn } }
-{ $description "Maps the vreg to the instruction that defined it." } ;
+{ $description "Maps the vreg to the instruction that defined it." }
+{ $see-also compute-insns } ;
 
 HELP: temp-vregs
 { $values { "insn" insn } { "seq" sequence } }
@@ -43,7 +52,7 @@ HELP: special-vreg-insns
 ARTICLE: "compiler.cfg.def-use" "Common code used by several passes for def-use analysis"
 "The " { $vocab-link "compiler.cfg.def-use" } " contains tools to correlate SSA instructions with virtual registers defined or used by them."
 $nl
-"Vregs for a given instruction:"
+"The def-use protocol -- vregs for a given instruction:"
 { $subsections
   defs-vregs
   temp-vregs

--- a/basis/compiler/cfg/def-use/def-use.factor
+++ b/basis/compiler/cfg/def-use/def-use.factor
@@ -11,7 +11,6 @@ IN: compiler.cfg.def-use
 
 ! Utilities for iterating over instruction operands
 
-! Def-use protocol
 GENERIC: defs-vregs ( insn -- seq )
 GENERIC: temp-vregs ( insn -- seq )
 GENERIC: uses-vregs ( insn -- seq )

--- a/basis/compiler/cfg/intrinsics/fixnum/fixnum-docs.factor
+++ b/basis/compiler/cfg/intrinsics/fixnum/fixnum-docs.factor
@@ -1,5 +1,10 @@
-USING: compiler.cfg.instructions help.markup help.syntax ;
+USING: compiler.cfg.instructions help.markup help.syntax layouts math ;
 IN: compiler.cfg.intrinsics.fixnum
+
+HELP: fixnum*overflow
+{ $values { "x" fixnum } { "y" fixnum } { "z" bignum } }
+{ $description "Word called to perform a fixnum multiplication when the product overflows the value storable in " { $link cell } "." }
+{ $see-also most-negative-fixnum most-positive-fixnum } ;
 
 HELP: emit-fixnum-comparison
 { $values { "cc" "comparison symbol" } }

--- a/basis/compiler/cfg/linear-scan/allocation/allocation-docs.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation-docs.factor
@@ -9,8 +9,7 @@ HELP: (allocate-registers)
 
 HELP: allocate-registers
 { $values
-  { "live-intervals" sequence }
-  { "sync-point" sequence }
+  { "intervals/sync-points" sequence }
   { "registers" assoc }
   { "live-intervals'" sequence }
 }

--- a/basis/compiler/cfg/linear-scan/allocation/allocation.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation.factor
@@ -63,6 +63,6 @@ M: sync-point handle ( sync-point -- )
     handled-intervals get
     active-intervals inactive-intervals [ get values concat ] bi@ 3append ;
 
-: allocate-registers ( live-intervals sync-point registers -- live-intervals' )
+: allocate-registers ( intervals/sync-point registers -- live-intervals' )
     init-allocator unhandled-min-heap get (allocate-registers)
     gather-intervals ;

--- a/basis/compiler/cfg/linear-scan/allocation/allocation.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation.factor
@@ -63,6 +63,6 @@ M: sync-point handle ( sync-point -- )
     handled-intervals get
     active-intervals inactive-intervals [ get values concat ] bi@ 3append ;
 
-: allocate-registers ( intervals/sync-point registers -- live-intervals' )
+: allocate-registers ( intervals/sync-points registers -- live-intervals' )
     init-allocator unhandled-min-heap get (allocate-registers)
     gather-intervals ;

--- a/basis/compiler/cfg/linear-scan/allocation/state/state-docs.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state-docs.factor
@@ -50,8 +50,7 @@ HELP: inactive-intervals
 
 HELP: init-allocator
 { $values
-  { "live-intervals" { $link sequence } " of " { $link live-interval-state } }
-  { "sync-points" { $link sequence } " of " { $link sync-point } }
+  { "intervals/sync-points" { $link sequence } " of " { $link live-interval-state } " and " { $link sync-point } "." }
   { "registers" { $link assoc } " mapping from register class to available machine registers." }
 }
 { $description "Initializes the state for the register allocator." }

--- a/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
@@ -9,7 +9,7 @@ IN: compiler.cfg.linear-scan.allocation.state.tests
 {
     V{ T{ live-interval-state { reg-class int-regs } { vreg 123 } } }
 } [
-    f f machine-registers init-allocator
+    f machine-registers init-allocator
     T{ live-interval-state { reg-class int-regs } { vreg 123 } }
     [ add-active ] keep active-intervals-for
 ] unit-test
@@ -29,7 +29,7 @@ IN: compiler.cfg.linear-scan.allocation.state.tests
         { float-regs V{ } }
     }
 } [
-    f f machine-registers init-allocator
+    f machine-registers init-allocator
     T{ live-interval-state { reg-class int-regs } { vreg 123 } } add-active
     active-intervals get
 ] unit-test
@@ -164,8 +164,6 @@ cpu x86.64? [
         T{ live-interval-state { start 20 } { end 30 } }
         T{ live-interval-state { start 20 } { end 28 } }
         T{ live-interval-state { start 33 } { end 999 } }
-    }
-    {
         T{ sync-point { n 5 } }
         T{ sync-point { n 33 } }
         T{ sync-point { n 100 } }
@@ -177,5 +175,5 @@ cpu x86.64? [
     {
         T{ live-interval-state { start 20 } { end 30 } }
         T{ live-interval-state { start 20 } { end 30 } }
-    } { } >unhandled-min-heap heap-size
+    } >unhandled-min-heap heap-size
 ] unit-test

--- a/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
@@ -137,27 +137,27 @@ cpu x86.64? [
     cfg get
 ] unit-test
 
-{ { 33 1/0.0 } } [
-    T{ sync-point { n 33 } } sync-point-key
+{ { 33 1/0.0 1/0.0 } } [
+    T{ sync-point { n 33 } } interval/sync-point-key
 ] unit-test
 
 {
     {
-        { { 5 1/0. } T{ sync-point { n 5 } } }
+        { { 5 1/0. 1/0. } T{ sync-point { n 5 } } }
         {
-            { 20 28 }
+            { 20 28 f }
             T{ live-interval-state { start 20 } { end 28 } }
         }
         {
-            { 20 30 }
+            { 20 30 f }
             T{ live-interval-state { start 20 } { end 30 } }
         }
         {
-            { 33 999 }
+            { 33 999 f }
             T{ live-interval-state { start 33 } { end 999 } }
         }
-        { { 33 1/0. } T{ sync-point { n 33 } } }
-        { { 100 1/0. } T{ sync-point { n 100 } } }
+        { { 33 1/0. 1/0. } T{ sync-point { n 33 } } }
+        { { 100 1/0. 1/0. } T{ sync-point { n 100 } } }
     }
 } [
     {

--- a/basis/compiler/cfg/linear-scan/allocation/state/state.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state.factor
@@ -26,11 +26,8 @@ M: live-interval-state interval/sync-point-key
 M: sync-point interval/sync-point-key
     n>> 1/0. 1/0. 3array ;
 
-: zip-keyed ( seq quot: ( elt -- key ) -- alist )
-    [ keep ] curry { } map>assoc ; inline
-
-: >unhandled-min-heap ( live-intervals sync-points -- min-heap )
-    append [ interval/sync-point-key ] zip-keyed >min-heap ;
+: >unhandled-min-heap ( intervals/sync-points -- min-heap )
+    [ [ interval/sync-point-key ] keep 2array ] map >min-heap ;
 
 SYMBOL: registers
 
@@ -134,7 +131,7 @@ SYMBOL: spill-slots
 : lookup-spill-slot ( coalesced-vreg rep -- spill-slot )
     rep-size 2array spill-slots get ?at [ ] [ bad-vreg ] if ;
 
-: init-allocator ( live-intervals sync-points registers -- )
+: init-allocator ( intervals/sync-points registers -- )
     registers set
     >unhandled-min-heap unhandled-min-heap set
     [ V{ } clone ] reg-class-assoc active-intervals set

--- a/basis/compiler/cfg/linear-scan/allocation/state/state.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state.factor
@@ -18,18 +18,19 @@ SYMBOL: progress
 
 SYMBOL: unhandled-min-heap
 
-: live-interval-key ( live-interval -- key )
-    [ start>> ] [ end>> ] bi 2array ;
+GENERIC: interval/sync-point-key ( interval/sync-point -- key )
 
-: sync-point-key ( sync-point -- key )
-    n>> 1/0. 2array ;
+M: live-interval-state interval/sync-point-key
+    [ start>> ] [ end>> ] [ vreg>> ] tri 3array ;
+
+M: sync-point interval/sync-point-key
+    n>> 1/0. 1/0. 3array ;
 
 : zip-keyed ( seq quot: ( elt -- key ) -- alist )
     [ keep ] curry { } map>assoc ; inline
 
 : >unhandled-min-heap ( live-intervals sync-points -- min-heap )
-    [ [ live-interval-key ] zip-keyed ]
-    [ [ sync-point-key ] zip-keyed ] bi* append >min-heap ;
+    append [ interval/sync-point-key ] zip-keyed >min-heap ;
 
 SYMBOL: registers
 
@@ -108,10 +109,8 @@ ERROR: register-already-used live-interval ;
     } process-intervals ;
 
 : add-unhandled ( live-interval -- )
-    [ check-unhandled ]
-    [
-        dup live-interval-key unhandled-min-heap get heap-push
-    ] bi ;
+    dup check-unhandled
+    dup interval/sync-point-key unhandled-min-heap get heap-push ;
 
 : reg-class-assoc ( quot -- assoc )
     [ reg-classes ] dip { } map>assoc ; inline

--- a/basis/compiler/cfg/linear-scan/debugger/debugger.factor
+++ b/basis/compiler/cfg/linear-scan/debugger/debugger.factor
@@ -10,7 +10,6 @@ IN: compiler.cfg.linear-scan.debugger
     [
         [ clone ] map dup [ [ vreg>> ] keep ] H{ } map>assoc
         live-intervals set
-        f
     ] dip
     allocate-registers drop ;
 

--- a/basis/compiler/cfg/linear-scan/linear-scan-docs.factor
+++ b/basis/compiler/cfg/linear-scan/linear-scan-docs.factor
@@ -5,6 +5,10 @@ HELP: admissible-registers
 { $values { "cfg" cfg } { "regs" assoc } }
 { $description "Lists all registers usable by the cfg by register class. In general, that's all registers except the frame pointer register that might be used by the cfg for other purposes." } ;
 
+HELP: linear-scan
+{ $values { "cfg" cfg } }
+{ $description "Entry point for the linear scan register alloation pass." } ;
+
 ARTICLE: "compiler.cfg.linear-scan" "Linear-scan register allocation"
 "Linear scan to assign physical registers. SSA liveness must have been computed already."
 $nl
@@ -13,7 +17,8 @@ $nl
   "Linear Scan Register Allocation by Massimiliano Poletto and Vivek Sarkar http://www.cs.ucla.edu/~palsberg/course/cs132/linearscan.pdf"
   "Linear Scan Register Allocation for the Java HotSpot Client Compiler by Christian Wimmer and http://www.ssw.uni-linz.ac.at/Research/Papers/Wimmer04Master/"
   "Quality and Speed in Linear-scan Register Allocation by Omri Traub, Glenn Holloway, Michael D. Smith http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.34.8435"
-} ;
-
+}
+"Optimization pass entry point:"
+{ $subsections linear-scan } ;
 
 ABOUT: "compiler.cfg.linear-scan"

--- a/basis/compiler/cfg/linear-scan/linear-scan-tests.factor
+++ b/basis/compiler/cfg/linear-scan/linear-scan-tests.factor
@@ -40,7 +40,7 @@ V{
 : test-live-intervals ( -- )
     0 get block>cfg
     [ cfg set ] [ number-instructions ] [ compute-live-intervals ] tri
-    2drop ;
+    drop ;
 
 [ ] [
     H{

--- a/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-docs.factor
+++ b/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-docs.factor
@@ -16,7 +16,7 @@ HELP: block-from
 { $description "The instruction number immediately preceeding this block." } ;
 
 HELP: finish-live-intervals
-{ $values { "live-intervals" sequence } { "seq" sequence } }
+{ $values { "live-intervals" sequence } }
 { $description "Since live intervals are computed in a backward order, we have to reverse some sequences, and compute the start and end." } ;
 
 HELP: from

--- a/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-docs.factor
+++ b/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-docs.factor
@@ -19,6 +19,9 @@ HELP: finish-live-intervals
 { $values { "live-intervals" sequence } { "seq" sequence } }
 { $description "Since live intervals are computed in a backward order, we have to reverse some sequences, and compute the start and end." } ;
 
+HELP: from
+{ $var-description "An integer representing a sequence number one lower than all numbers in the currently processed block." } ;
+
 HELP: live-interval-state
 { $class-description "A class encoding the \"liveness\" of a virtual register. It has the following slots:"
   { $table
@@ -58,6 +61,9 @@ HELP: live-interval-state
 HELP: live-intervals
 { $var-description "Mapping from vreg to " { $link live-interval-state } "." } ;
 
+HELP: live-range
+{ $class-description "Represents a range in the " { $link cfg } " in which a vreg is live." } ;
+
 HELP: sync-point
 { $class-description "A location where all registers have to be spilled. For example when garbage collection is run or an alien ffi call is invoked. Figuring out where in the " { $link cfg } " the sync points are is done in the " { $link compute-live-intervals } " step. The tuple has the following slots:"
   { $table
@@ -68,3 +74,20 @@ HELP: sync-point
 
 HELP: sync-points
 { $var-description "Sequence of sync points." } ;
+
+HELP: to
+{ $var-description "An integer representing a sequence number equal to the highest number in the currently processed block." } ;
+
+ARTICLE: "compiler.cfg.linear-scan.live-intervals" "Live interval utilities"
+"This vocab contains words for managing live intervals."
+$nl
+"Liveness classes and constructors:"
+{ $subsections
+  <live-interval>
+  <live-range>
+  live-interval
+  live-range
+} ;
+
+
+ABOUT: "compiler.cfg.linear-scan.live-intervals"

--- a/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-tests.factor
+++ b/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-tests.factor
@@ -1,4 +1,6 @@
-USING: compiler.cfg.linear-scan.live-intervals cpu.architecture kernel
+USING: arrays compiler.cfg compiler.cfg.linear-scan.live-intervals
+compiler.cfg.liveness compiler.cfg.registers
+compiler.cfg.ssa.destruction.leaders cpu.architecture kernel namespaces
 sequences tools.test ;
 IN: compiler.cfg.linear-scan.live-intervals.tests
 
@@ -13,4 +15,62 @@ IN: compiler.cfg.linear-scan.live-intervals.tests
 } [
     5 int-rep <live-interval> dup
     { { 5 10 } { 8 12 } } [ first2 rot add-range ] with each
+] unit-test
+
+{
+    T{ live-interval-state
+       { vreg 5 }
+       { ranges V{ T{ live-range { from 5 } { to 12 } } } }
+       { uses V{ } }
+       { reg-class int-rep }
+    }
+} [
+    5 int-rep <live-interval> dup
+    { { 10 12 } { 5 10 } } [ first2 rot add-range ] with each
+] unit-test
+
+! handle-live-out
+{ } [
+    H{ } clone live-outs set
+    <basic-block> handle-live-out
+] unit-test
+
+{
+    H{
+        {
+            8
+            T{ live-interval-state
+               { vreg 8 }
+               { ranges V{ T{ live-range { from -10 } { to 23 } } } }
+               { uses V{ } }
+               { reg-class int-regs }
+            }
+        }
+        {
+            9
+            T{ live-interval-state
+               { vreg 9 }
+               { ranges V{ T{ live-range { from -10 } { to 23 } } } }
+               { uses V{ } }
+               { reg-class int-regs }
+            }
+        }
+        {
+            4
+            T{ live-interval-state
+               { vreg 4 }
+               { ranges V{ T{ live-range { from -10 } { to 23 } } } }
+               { uses V{ } }
+               { reg-class int-regs }
+            }
+        }
+    }
+} [
+    -10 from set
+    23 to set
+    init-live-intervals
+    H{ { 4 4 } { 8 8 } { 9 9 } } leader-map set
+    H{ { 4 int-rep } { 8 int-rep } { 9 int-rep } } representations set
+    <basic-block> [ H{ { 4 4 } { 8 8 } { 9 9 } } 2array 1array live-outs set ]
+    [ handle-live-out ] bi live-intervals get
 ] unit-test

--- a/basis/compiler/cfg/linear-scan/live-intervals/live-intervals.factor
+++ b/basis/compiler/cfg/linear-scan/live-intervals/live-intervals.factor
@@ -154,10 +154,8 @@ M: hairy-clobber-insn compute-live-intervals* ( insn -- )
     2tri ;
 
 : handle-live-out ( bb -- )
-    live-out dup assoc-empty? [ drop ] [
-        [ from get to get ] dip keys
-        [ live-interval add-range ] 2with each
-    ] if ;
+    [ from get to get ] dip live-out keys
+    [ live-interval add-range ] 2with each ;
 
 TUPLE: sync-point n keep-dst? ;
 
@@ -202,8 +200,8 @@ ERROR: bad-live-interval live-interval ;
 : check-start ( live-interval -- )
     dup start>> -1 = [ bad-live-interval ] [ drop ] if ;
 
-: finish-live-intervals ( live-intervals -- seq )
-    values dup [
+: finish-live-intervals ( live-intervals -- )
+    [
         {
             [ [ { } like reverse! ] change-ranges drop ]
             [ [ { } like reverse! ] change-uses drop ]
@@ -212,12 +210,12 @@ ERROR: bad-live-interval live-interval ;
         } cleave
     ] each ;
 
-: compute-live-intervals ( cfg -- live-intervals sync-points )
+: compute-live-intervals ( cfg -- intervals/sync-points )
     init-live-intervals
-    linearization-order <reversed> [ kill-block?>> ] reject
+    linearization-order [ kill-block?>> ] reject <reversed>
     [ compute-live-intervals-step ] each
-    live-intervals get finish-live-intervals
-    sync-points get ;
+    live-intervals get values dup finish-live-intervals
+    sync-points get append ;
 
 : relevant-ranges ( interval1 interval2 -- ranges1 ranges2 )
     [ [ ranges>> ] bi@ ] [ nip start>> ] 2bi '[ to>> _ >= ] filter ;

--- a/basis/compiler/cfg/liveness/liveness-docs.factor
+++ b/basis/compiler/cfg/liveness/liveness-docs.factor
@@ -38,6 +38,9 @@ HELP: live-ins
 { $var-description "Hash that maps from basic blocks to vregs that are live in them." }
 { $see-also compute-live-sets } ;
 
+HELP: live-outs
+{ $var-description "Hash that maps from basic blocks to sets of vregs that are live after execution leaves the block." } ;
+
 HELP: lookup-base-pointer
 { $values { "vreg" "vreg" } { "vreg/f" { $maybe "vreg" } } }
 { $description "Tries to figure out what the base pointer for a vreg is. Can't use cache here because of infinite recursion inside the quotation passed to cache" }
@@ -53,6 +56,9 @@ $nl
 }
 $nl
 "Querying liveness data:"
-{ $subsections live-in live-in? live-out live-out? } ;
+{ $subsections
+  live-in live-in? live-ins
+  live-out live-out? live-outs
+} ;
 
 ABOUT: "compiler.cfg.liveness"

--- a/basis/compiler/cfg/parallel-copy/parallel-copy-docs.factor
+++ b/basis/compiler/cfg/parallel-copy/parallel-copy-docs.factor
@@ -16,6 +16,9 @@ HELP: parallel-copy-rep
 { $description "Creates " { $link ##copy } " instructions. Representation selection must have been run previously." } ;
 
 ARTICLE: "compiler.cfg.parallel-copy" "Parallel copy"
-"Revisiting Out-of-SSA Translation for Correctness, Code Quality, and Efficiency http://hal.archives-ouvertes.fr/docs/00/34/99/25/PDF/OutSSA-RR.pdf, Algorithm 1" ;
+"Revisiting Out-of-SSA Translation for Correctness, Code Quality, and Efficiency http://hal.archives-ouvertes.fr/docs/00/34/99/25/PDF/OutSSA-RR.pdf, Algorithm 1"
+$nl
+"Generating " { $link ##copy } " instructions:"
+{ $subsections parallel-copy parallel-copy-rep } ;
 
 ABOUT: "compiler.cfg.parallel-copy"

--- a/basis/compiler/cfg/ssa/construction/construction-docs.factor
+++ b/basis/compiler/cfg/ssa/construction/construction-docs.factor
@@ -1,6 +1,10 @@
-USING: compiler.cfg.instructions compiler.cfg.ssa.construction.private
-help.markup help.syntax ;
+USING: compiler.cfg compiler.cfg.instructions
+compiler.cfg.ssa.construction.private help.markup help.syntax ;
 IN: compiler.cfg.ssa.construction
+
+HELP: <##phi>
+{ $values { "vreg" "vreg" } { "bb" basic-block } { "##phi" ##phi } }
+{ $description "Creates a new " { $link ##phi } " instruction given a vreg and a basic block." } ;
 
 HELP: phis
 { $var-description "Maps vregs to " { $link ##phi } " instructions." } ;
@@ -16,6 +20,12 @@ HELP: defs-multi
 
 HELP: inserting-phis
 { $var-description "Maps basic blocks to sequences of " { $link ##phi } " instructions." } ;
+
+HELP: pushed
+{ $var-description "Maps vregs to renaming stacks." } ;
+
+HELP: stacks
+{ $var-description "Maps vregs to renaming stacks." } ;
 
 ARTICLE: "compiler.cfg.ssa.construction" "SSA construction"
 "Iterated dominance frontiers are computed using the DJ Graph method in " { $vocab-link "compiler.cfg.ssa.construction.tdmsc" } "."

--- a/basis/compiler/cfg/ssa/construction/construction.factor
+++ b/basis/compiler/cfg/ssa/construction/construction.factor
@@ -4,10 +4,10 @@ USING: accessors assocs combinators compiler.cfg
 compiler.cfg.def-use compiler.cfg.dominance
 compiler.cfg.instructions compiler.cfg.registers
 compiler.cfg.renaming.functor compiler.cfg.rpo
-compiler.cfg.ssa.construction.tdmsc deques dlists fry kernel
-math namespaces sequences sets ;
+compiler.cfg.ssa.construction.tdmsc compiler.cfg.utilities deques dlists fry
+kernel math sequences sets ;
 FROM: assocs => change-at ;
-FROM: namespaces => set ;
+FROM: namespaces => set get ;
 IN: compiler.cfg.ssa.construction
 
 <PRIVATE
@@ -36,9 +36,11 @@ M: vreg-insn compute-insn-defs
 
 SYMBOL: inserting-phis
 
+: <##phi> ( vreg bb -- ##phi )
+    predecessors>> over '[ _ ] H{ } map>assoc ##phi new-insn ;
+
 : insert-phi-later ( vreg bb -- )
-    [ predecessors>> over '[ _ ] H{ } map>assoc ##phi new-insn ] keep
-    inserting-phis get push-at ;
+    [ <##phi> ] keep inserting-phis get push-at ;
 
 : compute-phis-for ( vreg bbs -- )
     members merge-set [ insert-phi-later ] with each ;
@@ -52,7 +54,6 @@ SYMBOL: phis
 
 SYMBOL: used-vregs
 
-! Maps vregs to renaming stacks
 SYMBOLS: stacks pushed ;
 
 : init-renaming ( -- )
@@ -124,8 +125,7 @@ M: vreg-insn rename-insn
     pop-stacks ;
 
 : rename ( cfg -- )
-    init-renaming
-    entry>> rename-in-block ;
+    init-renaming entry>> rename-in-block ;
 
 ! Live phis
 SYMBOL: live-phis

--- a/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
@@ -1,6 +1,6 @@
 USING: compiler.cfg compiler.cfg.instructions
 compiler.cfg.ssa.destruction.private compiler.cfg.ssa.interference help.markup
-help.syntax kernel ;
+help.syntax kernel sequences ;
 IN: compiler.cfg.ssa.destruction
 
 HELP: class-element-map
@@ -25,7 +25,12 @@ HELP: copies
 HELP: try-eliminate-copy
 { $values { "follower" "vreg" } { "leader" "vreg" } { "must?" boolean } }
 { $description "Tries to eliminate a vreg copy from 'leader' to 'follower'. If 'must?' is " { $link t } " then a " { $link vregs-shouldn't-interfere } " error is thrown if the vregs interfere." }
-{ $see-also vregs-interfere? } ;
+{ $see-also try-eliminate-copies vregs-interfere? } ;
+
+HELP: try-eliminate-copies
+{ $values { "pairs" "a sequence of vreg pairs" } { "must?" boolean } }
+{ $description "Tries to eliminate the vreg copies in the " { $link sequence } " 'pairs'. If 'must?' is " { $link t } " then a " { $link vregs-shouldn't-interfere } " error is thrown if any of the vregs interfere. To ensure deterministic " { $link leader-map } " data, the pairs are sorted." }
+{ $see-also try-eliminate-copy } ;
 
 ARTICLE: "compiler.cfg.ssa.destruction" "SSA Destruction"
 "Because of the design of the register allocator, this pass has three peculiar properties."
@@ -33,6 +38,9 @@ ARTICLE: "compiler.cfg.ssa.destruction" "SSA Destruction"
   "Instead of renaming vreg usages in the CFG, a map from vregs to canonical representatives is computed. This allows the register allocator to use the original SSA names to get reaching definitions."
   { "Useless " { $link ##copy } " instructions, and all " { $link ##phi } " instructions, are eliminated, so the register allocator does not have to remove any redundant operations." }
   { "This pass computes live sets and fills out the " { $slot "gc-roots" } " slots of GC maps with " { $vocab-link "compiler.cfg.liveness" } ", so the linear scan register allocator does not need to compute liveness again." }
-} ;
+}
+$nl
+"Main entry point:"
+{ $subsections destruct-ssa } ;
 
 ABOUT: "compiler.cfg.ssa.destruction"

--- a/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
@@ -1,27 +1,31 @@
 USING: compiler.cfg compiler.cfg.instructions
-compiler.cfg.ssa.destruction.private help.markup help.syntax ;
+compiler.cfg.ssa.destruction.private compiler.cfg.ssa.interference help.markup
+help.syntax kernel ;
 IN: compiler.cfg.ssa.destruction
 
 HELP: class-element-map
-{ $var-description "Maps leaders to equivalence class elements." } ;
+{ $var-description "Maps leaders to equivalence class elements which are sequences of " { $link vreg-info } " instances." } ;
 
 HELP: cleanup-cfg
 { $values { "cfg" cfg } }
 { $description "In this step, " { $link ##parallel-copy } " instructions are substituted with more concreete " { $link ##copy } " instructions. " { $link ##phi } " instructions are removed here." } ;
 
+HELP: coalesce-elements
+{ $values { "merged" "??" } { "follower" "vreg" } { "leader" "vreg" } }
+{ $description "Delete follower's class, and set leaders's class to merged." } ;
+
+HELP: coalesce-vregs
+{ $values { "merged" "??" } { "follower" "vreg" } { "leader" "vreg" } }
+{ $description "Sets 'leader' as the leader of 'follower'." } ;
+
 HELP: copies
 { $var-description "Sequence of copies (tuples of { vreg-dst vreg-src}) that maybe can be eliminated later." }
 { $see-also init-coalescing } ;
 
-HELP: maybe-eliminate-copy
-{ $values { "vreg1" "vreg" } { "vreg2" "vreg" } }
-{ $description "Eliminate a copy if possible." }
-{ $see-also must-eliminate-copy } ;
-
-HELP: must-eliminate-copy
-{ $values { "vreg1" "vreg" } { "vreg2" "vreg" } }
-{ $description "Eliminates a copy." }
-{ $see-also maybe-eliminate-copy } ;
+HELP: try-eliminate-copy
+{ $values { "follower" "vreg" } { "leader" "vreg" } { "must?" boolean } }
+{ $description "Tries to eliminate a vreg copy from 'leader' to 'follower'. If 'must?' is " { $link t } " then a " { $link vregs-shouldn't-interfere } " error is thrown if the vregs interfere." }
+{ $see-also vregs-interfere? } ;
 
 ARTICLE: "compiler.cfg.ssa.destruction" "SSA Destruction"
 "Because of the design of the register allocator, this pass has three peculiar properties."

--- a/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
@@ -1,6 +1,6 @@
 USING: compiler.cfg compiler.cfg.instructions
-compiler.cfg.ssa.destruction.private compiler.cfg.ssa.interference help.markup
-help.syntax kernel sequences ;
+compiler.cfg.ssa.destruction.private compiler.cfg.ssa.destruction.leaders
+compiler.cfg.ssa.interference help.markup help.syntax kernel sequences ;
 IN: compiler.cfg.ssa.destruction
 
 HELP: class-element-map

--- a/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
@@ -2,9 +2,26 @@ USING: compiler.cfg compiler.cfg.instructions
 compiler.cfg.ssa.destruction.private help.markup help.syntax ;
 IN: compiler.cfg.ssa.destruction
 
+HELP: class-element-map
+{ $var-description "Maps leaders to equivalence class elements." } ;
+
 HELP: cleanup-cfg
 { $values { "cfg" cfg } }
 { $description "In this step, " { $link ##parallel-copy } " instructions are substituted with more concreete " { $link ##copy } " instructions. " { $link ##phi } " instructions are removed here." } ;
+
+HELP: copies
+{ $var-description "Sequence of copies (tuples of { vreg-dst vreg-src}) that maybe can be eliminated later." }
+{ $see-also init-coalescing } ;
+
+HELP: maybe-eliminate-copy
+{ $values { "vreg1" "vreg" } { "vreg2" "vreg" } }
+{ $description "Eliminate a copy if possible." }
+{ $see-also must-eliminate-copy } ;
+
+HELP: must-eliminate-copy
+{ $values { "vreg1" "vreg" } { "vreg2" "vreg" } }
+{ $description "Eliminates a copy." }
+{ $see-also maybe-eliminate-copy } ;
 
 ARTICLE: "compiler.cfg.ssa.destruction" "SSA Destruction"
 "Because of the design of the register allocator, this pass has three peculiar properties."

--- a/basis/compiler/cfg/ssa/destruction/destruction-tests.factor
+++ b/basis/compiler/cfg/ssa/destruction/destruction-tests.factor
@@ -1,8 +1,10 @@
-USING: alien.syntax compiler.cfg.def-use compiler.cfg.instructions
-compiler.cfg.registers compiler.cfg.ssa.destruction
-compiler.cfg.ssa.destruction.leaders
+USING: alien.syntax assocs compiler.cfg.def-use
+compiler.cfg.instructions compiler.cfg.registers
+compiler.cfg.ssa.destruction compiler.cfg.ssa.destruction.leaders
 compiler.cfg.ssa.destruction.private compiler.cfg.utilities
-cpu.architecture cpu.x86.assembler.operands kernel make namespaces tools.test ;
+cpu.architecture cpu.x86.assembler.operands grouping kernel make namespaces
+random sequences tools.test ;
+QUALIFIED: sets
 IN: compiler.cfg.ssa.destruction.tests
 
 ! cleanup-insn
@@ -63,9 +65,9 @@ IN: compiler.cfg.ssa.destruction.tests
     } 0 insns>block block>cfg destruct-ssa
 ] unit-test
 
-! must-eliminate-copy
+! try-eliminate-copy
 { } [
-    10 10 must-eliminate-copy
+    10 10 f try-eliminate-copy
 ] unit-test
 
 ! prepare-insn
@@ -79,4 +81,21 @@ IN: compiler.cfg.ssa.destruction.tests
     V{ } clone copies set
     T{ ##parallel-copy { values V{ { 3 4 } { 7 8 } } } } prepare-insn
     copies get
+] unit-test
+
+! All this work to make the 'values' order non-deterministic.
+: make-phi-inputs ( -- assoc )
+    H{ } clone [
+        { 2287 2288 } [
+            10 iota 1 sample first rot set-at
+        ] with each
+    ] keep ;
+
+{ t } [
+    10 [
+        { 2286 2287 2288 } sets:unique leader-map set
+        2286 make-phi-inputs ##phi new-insn
+        prepare-insn
+        2286 leader
+    ] replicate all-equal?
 ] unit-test

--- a/basis/compiler/cfg/ssa/destruction/destruction-tests.factor
+++ b/basis/compiler/cfg/ssa/destruction/destruction-tests.factor
@@ -2,7 +2,7 @@ USING: alien.syntax compiler.cfg.def-use compiler.cfg.instructions
 compiler.cfg.registers compiler.cfg.ssa.destruction
 compiler.cfg.ssa.destruction.leaders
 compiler.cfg.ssa.destruction.private compiler.cfg.utilities
-cpu.architecture cpu.x86.assembler.operands make namespaces tools.test ;
+cpu.architecture cpu.x86.assembler.operands kernel make namespaces tools.test ;
 IN: compiler.cfg.ssa.destruction.tests
 
 ! cleanup-insn
@@ -61,4 +61,22 @@ IN: compiler.cfg.ssa.destruction.tests
            { insn# 18 }
         }
     } 0 insns>block block>cfg destruct-ssa
+] unit-test
+
+! must-eliminate-copy
+{ } [
+    10 10 must-eliminate-copy
+] unit-test
+
+! prepare-insn
+{ V{ { 2 1 } } } [
+    V{ } clone copies set
+    T{ ##copy { src 1 } { dst 2 } { rep int-rep } } prepare-insn
+    copies get
+] unit-test
+
+{ V{ { 3 4 } { 7 8 } } } [
+    V{ } clone copies set
+    T{ ##parallel-copy { values V{ { 3 4 } { 7 8 } } } } prepare-insn
+    copies get
 ] unit-test

--- a/basis/compiler/cfg/ssa/destruction/leaders/leaders-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/leaders/leaders-docs.factor
@@ -1,8 +1,13 @@
-USING: help.markup help.syntax math ;
+USING: compiler.cfg.ssa.destruction.private help.markup help.syntax math ;
 IN: compiler.cfg.ssa.destruction.leaders
 
+HELP: ?leader
+{ $values { "vreg" "vreg" } { "vreg'" "vreg" } }
+{ $description "The leader of the vreg or the register itself if it has no other leader." } ;
+
 HELP: leader-map
-{ $var-description "A map from vregs to canonical representatives due to coalescing done by SSA destruction. Used by liveness analysis and the register allocator, so we can use the original SSA names to get certain info (reaching definitions, representations)." } ;
+{ $var-description "A map from vregs to canonical representatives due to coalescing done by SSA destruction. Used by liveness analysis and the register allocator, so we can use the original SSA names to get certain info (reaching definitions, representations). By default, each vreg is its own leader." }
+{ $see-also init-coalescing perform-coalescing } ;
 
 ARTICLE: "compiler.cfg.ssa.destruction.leaders" "Leader book-keeping" "This vocab defines words for getting the leaders of vregs." ;
 

--- a/basis/compiler/cfg/ssa/interference/interference-docs.factor
+++ b/basis/compiler/cfg/ssa/interference/interference-docs.factor
@@ -1,0 +1,20 @@
+USING: help.markup help.syntax ;
+IN: compiler.cfg.ssa.interference
+
+HELP: vreg-info
+{ $class-description
+  "Slots:"
+  { $table
+    { { $slot "vreg" } { "The vreg the vreg-info is the info for." } }
+  }
+} ;
+
+
+ARTICLE: "compiler.cfg.ssa.interference" "Interference testing using SSA properties."
+"Interference testing using SSA properties"
+$nl
+"Based on:"
+$nl
+"Revisiting Out-of-SSA Translation for Correctness, Code Quality, and Efficiency http://hal.archives-ouvertes.fr/docs/00/34/99/25/PDF/OutSSA-RR.pdf" ;
+
+ABOUT: "compiler.cfg.ssa.interference"

--- a/basis/compiler/cfg/ssa/interference/interference.factor
+++ b/basis/compiler/cfg/ssa/interference/interference.factor
@@ -5,13 +5,6 @@ compiler.cfg.dominance compiler.cfg.ssa.interference.live-ranges
 kernel locals math math.order sequences sorting.slots ;
 IN: compiler.cfg.ssa.interference
 
-! Interference testing using SSA properties.
-!
-! Based on:
-!
-! Revisiting Out-of-SSA Translation for Correctness, Code Quality, and Efficiency
-! http://hal.archives-ouvertes.fr/docs/00/34/99/25/PDF/OutSSA-RR.pdf
-
 TUPLE: vreg-info vreg value def-index bb pre-of color equal-anc-in equal-anc-out ;
 
 :: <vreg-info> ( vreg value bb -- info )

--- a/basis/compiler/codegen/gc-maps/gc-maps-docs.factor
+++ b/basis/compiler/codegen/gc-maps/gc-maps-docs.factor
@@ -1,32 +1,13 @@
-USING: bit-arrays byte-arrays compiler.cfg.instructions help.markup help.syntax
-kernel math ;
+USING: bit-arrays byte-arrays compiler.cfg compiler.cfg.instructions
+compiler.cfg.stack-frame help.markup help.syntax kernel math sequences ;
 IN: compiler.codegen.gc-maps
 
-ARTICLE: "compiler.codegen.gc-maps" "GC maps"
-"The " { $vocab-link "compiler.codegen.gc-maps" } " handles generating code for keeping track of garbage collection maps. Every code block either ends with:"
-{ $list "uint 0" }
-"or"
-{ $list
-  {
-      "bitmap, byte aligned, five subsequences:"
-      { $list
-        "scrubbed data stack locations"
-        "scrubbed retain stack locations"
-        "GC root spill slots"
-      }
-  }
-  "uint[] base pointers"
-  "uint[] return addresses"
-  "uint largest scrubbed data stack location"
-  "uint largest scrubbed retain stack location"
-  "uint largest GC root spill slot"
-  "uint largest derived root spill slot"
-  "int number of return addresses"
-} ;
-
 HELP: emit-gc-info-bitmaps
-{ $values { "counts" "counts of the three different types of gc checks" } }
-{ $description "Emits the scrub location data in all gc-maps registered in the " { $link gc-maps } " variable to the make sequence being created. The result is a concatenation of all datastack scrub locations, retainstack scrub locations and gc root locations converted into a byte-array. Given that byte-array and knowledge of the number of scrub locations, the original gc-map can be reconstructed."  } ;
+{ $values
+  { "gc-maps" sequence }
+  { "counts" "counts of the three different types of gc checks" }
+}
+{ $description "Emits the scrub location data in the 'gc-maps' to the make sequence being created. The result is a concatenation of all datastack scrub locations, retainstack scrub locations and gc root locations converted into a byte-array. Given that byte-array and knowledge of the number of scrub locations, the original gc-map can be reconstructed."  } ;
 
 HELP: emit-scrub
 { $values
@@ -55,12 +36,19 @@ HELP: emit-uint
   }
 } ;
 
+HELP: emit-gc-maps
+{ $description "GC maps are emitted so that the end is aligned to a 16-byte boundary." } ;
+
 HELP: gc-maps
-{ $var-description "Variable that holds a sequence of " { $link gc-map } " tuples." } ;
+{ $var-description "Variable that holds a sequence of " { $link gc-map } " tuples. Gc maps are added to the sequence by " { $link gc-map-here } "." } ;
 
 HELP: gc-map-needed?
 { $values { "gc-map/f" { $maybe gc-map } } { "?" boolean } }
 { $description "If all slots in the gc-map are empty, then it doesn't need to be emitted." } ;
+
+HELP: gc-root-offsets
+{ $values { "gc-map" gc-map } { "offsets" sequence } }
+{ $description "Gets the offets of all roots in a gc-map. The " { $link stack-frame } " variable must have been setup first." } ;
 
 HELP: serialize-gc-maps
 { $values { "byte-array" byte-array } }
@@ -69,5 +57,31 @@ HELP: serialize-gc-maps
 HELP: gc-map-here
 { $values { "gc-map" gc-map } }
 { $description "Registers the gc map in the " { $link gc-maps } " dynamic variable at the current compiled offset." } ;
+
+ARTICLE: "compiler.codegen.gc-maps" "GC maps"
+"The " { $vocab-link "compiler.codegen.gc-maps" } " handles generating code for keeping track of garbage collection maps. Every code block either ends with:"
+{ $list "uint 0" }
+"or"
+{ $list
+  {
+      "bitmap, byte aligned, five subsequences:"
+      { $list
+        "scrubbed data stack locations"
+        "scrubbed retain stack locations"
+        "GC root spill slots"
+      }
+  }
+  "uint[] base pointers"
+  "uint[] return addresses"
+  "uint largest scrubbed data stack location"
+  "uint largest scrubbed retain stack location"
+  "uint largest GC root spill slot"
+  "uint largest derived root spill slot"
+  "int number of return addresses"
+}
+"The " { $link gc-map } " tuples of the " { $link cfg } " are serialized to the above format and placed directly after the generated code."
+$nl
+"Main entry point:"
+{ $subsections emit-gc-maps } ;
 
 ABOUT: "compiler.codegen.gc-maps"

--- a/basis/compiler/codegen/gc-maps/gc-maps-tests.factor
+++ b/basis/compiler/codegen/gc-maps/gc-maps-tests.factor
@@ -112,7 +112,7 @@ cpu x86.64? [
                    T{ spill-slot { n 0 } }
                    T{ spill-slot { n 24 } }
                } }
-            } 1array gc-maps set
+            } 1array
             [ emit-gc-info-bitmaps ] B{ } make drop
         ] with-variable
     ] unit-test
@@ -125,13 +125,23 @@ cpu x86.64? [
                    T{ spill-slot { n 0 } }
                    T{ spill-slot { n 24 } }
                } }
-            } 1array gc-maps set
+            } 1array
             [ emit-gc-info-bitmaps ] B{ } make drop
         ] with-variable
     ] unit-test
 
     fake-cpu \ cpu set
 ] when
+
+! largest-spill-slot
+{
+    5 0 4 1
+} [
+    { { 4 } } largest-spill-slot
+    { { } } largest-spill-slot
+    { { 2 3 } { 0 } } largest-spill-slot
+    { { 0 } } largest-spill-slot
+] unit-test
 
 ! gc-map-needed?
 { t t } [
@@ -149,7 +159,7 @@ cpu x86.64? [
     { 4 2 0 }
     V{ 1 }
 } [
-    { T{ gc-map { scrub-d { 0 1 1 1 } } { scrub-r { 1 1 } } } } gc-maps set
+    { T{ gc-map { scrub-d { 0 1 1 1 } } { scrub-r { 1 1 } } } }
     [ emit-gc-info-bitmaps ] V{ } make
 ] unit-test
 
@@ -157,7 +167,7 @@ cpu x86.64? [
     { 1 0 0 }
     V{ 1 }
 } [
-    { T{ gc-map { scrub-d { 0 } } } } gc-maps set
+    { T{ gc-map { scrub-d { 0 } } } }
     [ emit-gc-info-bitmaps ] V{ } make
 ] unit-test
 
@@ -174,7 +184,7 @@ USING: present prettyprint ;
 {
     3 B{ 255 255 255 255 255 255 255 255 4 0 0 0 }
 } [
-    { T{ gc-map { derived-roots V{ { 2 4 } } } } } gc-maps set
+    { T{ gc-map { derived-roots V{ { 2 4 } } } } }
     [ emit-base-tables ] B{ } make
 ] unit-test
 

--- a/basis/compiler/tree/cleanup/cleanup-docs.factor
+++ b/basis/compiler/tree/cleanup/cleanup-docs.factor
@@ -1,9 +1,15 @@
-USING: help.markup help.syntax sequences ;
+USING: compiler.tree help.markup help.syntax kernel sequences ;
 IN: compiler.tree.cleanup
 
-ARTICLE: "compiler.tree.cleanup" "Cleanup Phase"
-"A phase run after propagation to finish the job, so to speak. Codifies speculative inlining decisions, deletes branches marked as never taken, and flattens local recursive blocks that do not call themselves." ;
+HELP: cleanup-folding?
+{ $values { "#call" #call } { "?" boolean } }
+{ $description "Checks if a " { $link #call } " node can be folded." } ;
 
 HELP: cleanup-tree
 { $values { "nodes" sequence } { "nodes'" sequence } }
 { $description "Main entry point for the cleanup-tree optimization phase." } ;
+
+ARTICLE: "compiler.tree.cleanup" "Cleanup Phase"
+"A phase run after propagation to finish the job, so to speak. Codifies speculative inlining decisions, deletes branches marked as never taken, and flattens local recursive blocks that do not call themselves." ;
+
+ABOUT: "compiler.tree.cleanup"

--- a/basis/compiler/tree/dead-code/dead-code-docs.factor
+++ b/basis/compiler/tree/dead-code/dead-code-docs.factor
@@ -1,0 +1,6 @@
+USING: help.markup help.syntax ;
+IN: compiler.tree.dead-code
+
+ARTICLE: "compiler.tree.dead-code" "Dead code elimination" "In this compiler pass, nodes that have no effect on the words output are removed." ;
+
+ABOUT: "compiler.tree.dead-code"

--- a/basis/compiler/tree/propagation/info/info-docs.factor
+++ b/basis/compiler/tree/propagation/info/info-docs.factor
@@ -1,6 +1,14 @@
 USING: compiler.tree help.markup help.syntax sequences ;
 IN: compiler.tree.propagation.info
 
+HELP: node-input-infos
+{ $values { "node" node } { "seq" sequence } }
+{ $description "Lists the value infos for the input variables of an SSA tree node." } ;
+
+HELP: node-output-infos
+{ $values { "node" node } { "seq" sequence } }
+{ $description "Lists the value infos for the output variables of an SSA tree node." } ;
+
 HELP: value-info-state
 { $class-description "Represents constraints the compiler knows about the input and output variables to an SSA tree node. It has the following slots:"
   { $table
@@ -12,10 +20,5 @@ HELP: value-info-state
   }
 } ;
 
-HELP: node-input-infos
-{ $values { "node" node } { "seq" sequence } }
-{ $description "Lists the value infos for the input variables of an SSA tree node." } ;
-
-HELP: node-output-infos
-{ $values { "node" node } { "seq" sequence } }
-{ $description "Lists the value infos for the output variables of an SSA tree node." } ;
+HELP: value-infos
+{ $var-description "Assoc stack of current value --> info mapping" } ;

--- a/basis/compiler/tree/propagation/info/info.factor
+++ b/basis/compiler/tree/propagation/info/info.factor
@@ -286,7 +286,6 @@ DEFER: (value-info-union)
         ]
     } cond ;
 
-! Assoc stack of current value --> info mapping
 SYMBOL: value-infos
 
 : value-info* ( value -- info ? )

--- a/basis/compiler/tree/propagation/propagation-docs.factor
+++ b/basis/compiler/tree/propagation/propagation-docs.factor
@@ -50,3 +50,8 @@ HELP: propagate
 { $description "Performs the propagation pass of the AST optimization. All nodes info slots are initialized here." }
 { $examples { $unchecked-example $[ propagate-ex ] }
 } ;
+
+ARTICLE: "compiler.tree.propagation" "Class, interval, constant propagation"
+"This pass must be run after " { $vocab-link "compiler.tree.normalization" } "." ;
+
+ABOUT: "compiler.tree.propagation"

--- a/basis/compiler/tree/propagation/propagation.factor
+++ b/basis/compiler/tree/propagation/propagation.factor
@@ -16,8 +16,6 @@ compiler.tree.propagation.transforms
 kernel namespaces ;
 IN: compiler.tree.propagation
 
-! This pass must run after normalization
-
 : propagate ( nodes -- nodes )
     H{ } clone copies set
     H{ } clone 1array value-infos set

--- a/basis/cpu/architecture/architecture-docs.factor
+++ b/basis/cpu/architecture/architecture-docs.factor
@@ -292,7 +292,7 @@ HELP: stack-cleanup
 
 HELP: gc-root-offset
 { $values { "spill-slot" spill-slot } { "n" integer } }
-{ $description "Offset in the " { $link stack-frame } " for the word being constructed where the spill slot is located, in " { $link cell } " units." }
+{ $description "Offset in the " { $link stack-frame } " for the word being constructed where the spill slot is located. The value is given in " { $link cell } " units." }
 { $see-also vm:gc-info } ;
 
 ARTICLE: "cpu.architecture" "CPU architecture description model"
@@ -323,4 +323,14 @@ $nl
   widen-vector-rep
 }
 "Slot access:"
-{ $subsections %write-barrier } ;
+{ $subsections
+  %set-slot
+  %set-slot-imm
+  %slot
+  %slot-imm
+  %write-barrier
+}
+"Spilling:"
+{ $subsections gc-root-offset } ;
+
+ABOUT: "cpu.architecture"


### PR DESCRIPTION
Here is a branch I've worked on which should eliminate the #1345 bug and also add docs and refactor code. There were two problems, in ##phi nodes the vreg has more than one "parent" so which one was chooses as parent was random. I made it so the one with the lowest vreg nr always is choosen. The linear-scan step had the same problem so I changed the key from { start end } to { start end vreg } and because vreg nr is unique, it should make it so compilation becomes more deterministic.