### PR TITLE
Tab change focus

### DIFF
--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -629,6 +629,14 @@ M: field pref-dim*
     [ [ line-gadget-width ] [ drop second ] 2bi 2array ]
     tri border-pref-dim ;
 
+: next-focus ( gadget -- ) focus-next>> [ request-focus ] when* ;
+: prev-focus ( gadget -- ) focus-prev>> [ request-focus ] when* ;
+
+field H{
+    { T{ key-down f f "TAB" } [ next-focus ] }
+    { T{ key-down f { S+ } "TAB" } [ prev-focus ] }
+} set-gestures
+
 TUPLE: model-field < field field-model ;
 
 : <model-field> ( model -- gadget )
@@ -661,3 +669,5 @@ TUPLE: action-field < field quot ;
 action-field H{
     { T{ key-down f f "RET" } [ invoke-action-field ] }
 } set-gestures
+
+M: field focus-chainable? drop t ;

--- a/basis/ui/gadgets/gadgets.factor
+++ b/basis/ui/gadgets/gadgets.factor
@@ -24,7 +24,9 @@ layout-state
 graft-node
 interior
 boundary
-model ;
+model
+focus-prev
+focus-next ;
 
 M: gadget equal? 2drop f ;
 
@@ -394,6 +396,11 @@ M: f request-focus-on 2drop ;
 
 : focus-path ( gadget -- seq )
     [ focus>> ] follow ;
+
+GENERIC: link-focus-chain ( gadget -- {first,last} )
+GENERIC: focus-chainable? ( gadget -- t )
+M: gadget link-focus-chain dup focus-chainable? [ dup 2array ] [ drop f ] if ;
+M: gadget focus-chainable? drop f ;
 
 USE: vocabs.loader
 

--- a/basis/ui/gadgets/packs/packs.factor
+++ b/basis/ui/gadgets/packs/packs.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2005, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors arrays combinators fry kernel math math.order
-math.vectors sequences ui.baseline-alignment
+USING: accessors arrays combinators fry grouping kernel math
+math.order math.vectors sequences ui.baseline-alignment
 ui.baseline-alignment.private ui.gadgets ;
 IN: ui.gadgets.packs
 
@@ -101,3 +101,18 @@ M: pack layout*
 
 M: pack children-on ( rect gadget -- seq )
     [ orientation>> ] [ children>> ] bi [ loc>> ] fast-children-on ;
+
+: each-chains ( seq quot -- seq' )
+    [ 3 circular-clump ] [ [ first3 ] prepose ] bi* each ; inline
+
+: link-chain ( prev cur next -- )
+  [ second ] [ first2 ] [ first ] tri*
+  [ focus-prev<< ] [ swap focus-next<< ] 2bi* ;
+: link-chains ( chains -- )
+  [ link-chain ] each-chains ;
+: first/last ( chains -- {first,last} )
+  [ f ] [ [ first first ] [ last last ] bi 2array ] if-empty ;
+
+M: pack link-focus-chain ( gadget -- {first,last} )
+    children>> [ link-focus-chain ] map sift
+    [ link-chains ] [ first/last ] bi ;

--- a/basis/ui/gadgets/worlds/worlds.factor
+++ b/basis/ui/gadgets/worlds/worlds.factor
@@ -152,7 +152,8 @@ M: world apply-world-attributes
 
 M: world layout*
     [ call-next-method ]
-    [ dup layers>> [ as-big-as-possible ] with each ] bi ;
+    [ dup layers>> [ as-big-as-possible ] with each ]
+    [ link-focus-chain drop ] tri ;
 
 M: world focusable-child* children>> [ t ] [ first ] if-empty ;
 


### PR DESCRIPTION
Found this branch in my repo, not sure if I already submitted this. It looks good to me, it allows to change the focus with tab and shift tab, for example on :
```factor
<pile>
  "coucou" <model> <model-field> add-gadget
  "cocou" <model> <model-field> add-gadget
"coucou" open-window
```