### PR TITLE
Fix 1353

### DIFF
--- a/basis/compiler/cfg/linear-scan/allocation/allocation-docs.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation-docs.factor
@@ -1,11 +1,16 @@
 USING: assocs compiler.cfg compiler.cfg.instructions
 compiler.cfg.linear-scan.allocation compiler.cfg.linear-scan.allocation.state
-compiler.cfg.linear-scan.live-intervals help.markup help.syntax kernel sequences ;
+compiler.cfg.linear-scan.live-intervals hashtables help.markup help.syntax
+kernel sequences ;
 IN: compiler.cfg.linear-scan.allocation
 
 HELP: (allocate-registers)
 { $values { "unhandled-min-heap" "stuff" } }
 { $description "Register allocation works by emptying the unhandled intervals and sync points." } ;
+
+HELP: active-positions
+{ $values { "new" live-interval-state } { "assoc" assoc } }
+{ $description "Looks at the " { $link active-intervals } " and sets to 0 those registers in 'assoc' that can't be used for allocation." } ;
 
 HELP: allocate-registers
 { $values
@@ -14,6 +19,15 @@ HELP: allocate-registers
   { "live-intervals'" sequence }
 }
 { $description "Performs register allocation of a " { $link sequence } " of live intervals. Each live interval is assigned a physical register and also a spill slot if it needs to be spilled." } ;
+
+HELP: assign-register
+{ $values { "new" live-interval-state } { "registers" assoc } }
+{ $description "Assigns a processor register to the live interval." } ;
+
+HELP: free-positions
+{ $values { "registers" assoc } { "reg-class" } { "avail-registers" assoc } }
+{ $description "Creates an alist mapping registers to their desirability for allocation. 'avail-registers' is an alist and not a " { $link hashtable } " because the register allocation order is significant." }
+{ $see-also register-status } ;
 
 HELP: handle-sync-point
 { $values

--- a/basis/compiler/cfg/linear-scan/allocation/allocation-tests.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation-tests.factor
@@ -4,7 +4,7 @@ compiler.cfg.linear-scan.live-intervals cpu.architecture
 cpu.x86.assembler.operands heaps kernel namespaces system tools.test ;
 IN: compiler.cfg.linear-scan.allocation.tests
 
-: unassigned-interval ( -- live-interval )
+: interval-[30,46] ( -- live-interval )
     T{ live-interval-state
        { vreg 49 }
        { start 30 } { end 46 }
@@ -18,17 +18,31 @@ IN: compiler.cfg.linear-scan.allocation.tests
        { reg-class int-regs }
     } clone ;
 
+: interval-[30,60] ( -- live-interval )
+    T{ live-interval-state
+       { vreg 25 }
+       { start 30 } { end 60 }
+       { reg-class int-regs }
+       { reg RAX }
+    } ;
+
 cpu x86.64? [
     ! assign-registers
-    { R8 } [
-        { { int-regs V{ } } { float-regs V{ } } } active-intervals set
-        unassigned-interval dup machine-registers assign-register reg>>
+    { RAX } [
+        f machine-registers init-allocator
+        interval-[30,46] dup machine-registers assign-register reg>>
     ] unit-test
 
     ! register-status
-    { { R8 1/0. } } [
-        { { int-regs V{ } } { float-regs V{ } } } active-intervals set
-        unassigned-interval machine-registers register-status
+    { { RAX 1/0. } } [
+        f machine-registers init-allocator
+        interval-[30,46] machine-registers register-status
+    ] unit-test
+
+    { { RCX 1/0. } } [
+        f machine-registers init-allocator
+        interval-[30,60] add-active
+        interval-[30,46] machine-registers register-status
     ] unit-test
 ] when
 
@@ -83,7 +97,7 @@ cpu x86.64? [
     <min-heap> unhandled-min-heap set
     f f <basic-block> <cfg> cfg set
     40 progress set
-    T{ sync-point { n 40 } } unassigned-interval spill-at-sync-point
+    T{ sync-point { n 40 } } interval-[30,46] spill-at-sync-point
 ] unit-test
 
 ! spill-at-sync-point?

--- a/basis/compiler/cfg/linear-scan/allocation/allocation-tests.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation-tests.factor
@@ -39,7 +39,7 @@ cpu x86.64? [
         interval-[30,46] machine-registers register-status
     ] unit-test
 
-    { { RCX 1/0. } } [
+    { { RBX 1/0. } } [
         f machine-registers init-allocator
         interval-[30,60] add-active
         interval-[30,46] machine-registers register-status
@@ -49,9 +49,9 @@ cpu x86.64? [
     {
         {
             { RAX 1/0. }
+            { RBX 1/0. }
             { RCX 1/0. }
             { RDX 1/0. }
-            { RBX 1/0. }
             { RBP 1/0. }
             { RSI 1/0. }
             { RDI 1/0. }

--- a/basis/compiler/cfg/linear-scan/allocation/allocation-tests.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation-tests.factor
@@ -44,6 +44,26 @@ cpu x86.64? [
         interval-[30,60] add-active
         interval-[30,46] machine-registers register-status
     ] unit-test
+
+    ! free-positions
+    {
+        {
+            { RAX 1/0. }
+            { RCX 1/0. }
+            { RDX 1/0. }
+            { RBX 1/0. }
+            { RBP 1/0. }
+            { RSI 1/0. }
+            { RDI 1/0. }
+            { R8 1/0. }
+            { R9 1/0. }
+            { R10 1/0. }
+            { R11 1/0. }
+            { R12 1/0. }
+        }
+    } [
+        machine-registers int-regs free-positions
+    ] unit-test
 ] when
 
 ! handle-sync-point

--- a/basis/compiler/cfg/linear-scan/allocation/allocation.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation.factor
@@ -8,8 +8,7 @@ heaps kernel locals math namespaces sequences ;
 IN: compiler.cfg.linear-scan.allocation
 
 : active-positions ( new assoc -- )
-    [ active-intervals-for ] dip
-    '[ [ 0 ] dip reg>> _ add-use-position ] each ;
+    swap active-intervals-for [ reg>> 0 2array ] map assoc-union! drop ;
 
 : inactive-positions ( new assoc -- )
     [ [ inactive-intervals-for ] keep ] dip

--- a/basis/compiler/cfg/linear-scan/allocation/allocation.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/allocation.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2008, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors assocs combinators combinators.short-circuit
+USING: accessors arrays assocs combinators combinators.short-circuit
 compiler.cfg.linear-scan.allocation.spilling
 compiler.cfg.linear-scan.allocation.state
 compiler.cfg.linear-scan.live-intervals compiler.utilities fry
@@ -18,10 +18,13 @@ IN: compiler.cfg.linear-scan.allocation
         _ add-use-position
     ] each ;
 
+: free-positions ( registers reg-class -- avail-registers )
+    of [ 1/0. 2array ] map ;
+
 : register-status ( new registers -- free-pos )
-    over reg-class>> free-positions
-    [ inactive-positions ] [ active-positions ] [ nip ] 2tri
-    >alist alist-max ;
+    over reg-class>> free-positions [
+        [ inactive-positions ] [ active-positions ] 2bi
+    ] keep alist-max ;
 
 : no-free-registers? ( result -- ? )
     second 0 = ; inline

--- a/basis/compiler/cfg/linear-scan/allocation/state/state-docs.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state-docs.factor
@@ -33,14 +33,6 @@ HELP: deactivate-intervals
 { $values { "n" integer } }
 { $description "Any active intervals which have ended are moved to handled. Any active intervals which cover the current position are moved to inactive." } ;
 
-HELP: free-positions
-{ $values
-  { "registers" assoc }
-  { "reg-class" reg-class }
-  { "assoc" assoc }
-}
-{ $description "Returns an assoc with the registers that can be used by the live interval. A utility used by " { $link register-status } " word." } ;
-
 HELP: handled-intervals
 { $var-description { $link vector } " of handled live intervals. This variable I think is only used during the " { $link allocate-registers } " step." } ;
 

--- a/basis/compiler/cfg/linear-scan/allocation/state/state.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state.factor
@@ -3,8 +3,7 @@
 USING: accessors arrays assocs combinators compiler.cfg
 compiler.cfg.instructions
 compiler.cfg.linear-scan.live-intervals compiler.cfg.registers
-cpu.architecture fry heaps kernel linked-assocs math
-math.order namespaces sequences ;
+cpu.architecture fry heaps kernel math math.order namespaces sequences ;
 FROM: assocs => change-at ;
 IN: compiler.cfg.linear-scan.allocation.state
 
@@ -139,9 +138,6 @@ SYMBOL: spill-slots
     V{ } clone handled-intervals set
     H{ } clone spill-slots set
     -1 progress set ;
-
-: free-positions ( registers reg-class -- assoc )
-    of [ 1/0. ] H{ } <linked-assoc> map>assoc ;
 
 : add-use-position ( n reg assoc -- )
     [ [ min ] when* ] change-at ;

--- a/basis/cpu/x86/64/64.factor
+++ b/basis/cpu/x86/64/64.factor
@@ -32,7 +32,7 @@ M: x86.64 frame-reg RBP ;
 
 M: x86.64 machine-registers
     {
-        { int-regs { RAX RCX RDX RBX RBP RSI RDI R8 R9 R10 R11 R12 } }
+        { int-regs { RAX RBX RCX RDX RBP RSI RDI R8 R9 R10 R11 R12 } }
         { float-regs {
             XMM0 XMM1 XMM2 XMM3 XMM4 XMM5 XMM6 XMM7
             XMM8 XMM9 XMM10 XMM11 XMM12 XMM13 XMM14 XMM15


### PR DESCRIPTION
This pr should fix #1353. It makes the order in which registers are allocated more predictable.