### PR TITLE
Divmod propagation

### DIFF
--- a/basis/compiler/tree/propagation/inlining/inlining-tests.factor
+++ b/basis/compiler/tree/propagation/inlining/inlining-tests.factor
@@ -1,0 +1,8 @@
+USING: accessors compiler.tree.builder compiler.tree.propagation
+compiler.tree.propagation.inlining kernel math sequences tools.test ;
+IN: compiler.tree.propagation.inlining.tests
+
+{ t } [
+    [ >bignum 10 mod ] build-tree propagate
+    fourth dup word>> do-inlining
+] unit-test

--- a/basis/compiler/tree/propagation/known-words/known-words-tests.factor
+++ b/basis/compiler/tree/propagation/known-words/known-words-tests.factor
@@ -1,0 +1,21 @@
+USING: compiler.tree.propagation.known-words kernel math math.intervals
+tools.test ;
+IN: compiler.tree.propagation.known-words.tests
+
+{
+    fixnum
+    T{ interval { from { -19 t } } { to { 19 t } } }
+} [
+    integer
+    T{ interval { from { -19 t } } { to { 19 t } } }
+    maybe>fixnum
+] unit-test
+
+{
+    object
+    T{ interval { from { -19 t } } { to { 19 t } } }
+} [
+    object
+    T{ interval { from { -19 t } } { to { 19 t } } }
+    maybe>fixnum
+] unit-test

--- a/basis/compiler/tree/propagation/known-words/known-words-tests.factor
+++ b/basis/compiler/tree/propagation/known-words/known-words-tests.factor
@@ -1,21 +1,34 @@
-USING: compiler.tree.propagation.known-words kernel math math.intervals
-tools.test ;
+USING: accessors compiler.tree.propagation.info
+compiler.tree.propagation.known-words kernel kernel.private layouts math
+math.intervals math.private random tools.test words ;
 IN: compiler.tree.propagation.known-words.tests
 
 {
-    fixnum
-    T{ interval { from { -19 t } } { to { 19 t } } }
+    fixnum T{ interval { from { -19 t } } { to { 19 t } } }
 } [
-    integer
-    T{ interval { from { -19 t } } { to { 19 t } } }
-    maybe>fixnum
+    fixnum fixnum full-interval 0 20 [a,b] mod-merge-classes/intervals
 ] unit-test
 
 {
-    object
-    T{ interval { from { -19 t } } { to { 19 t } } }
+    object T{ interval { from { -20 f } } { to { 20 f } } }
 } [
-    object
-    T{ interval { from { -19 t } } { to { 19 t } } }
-    maybe>fixnum
+    object object full-interval 0 20 [a,b] mod-merge-classes/intervals
+] unit-test
+
+{ fixnum } [
+    bignum <class-info>
+    fixnum fixnum-interval <class/interval-info>
+    \ mod "outputs" word-prop call( x y -- z )
+    class>>
+] unit-test
+
+! Since 10 >bignum 5 >bignum bignum-mod => fixnum, the output class
+! must be integer.
+{ integer } [
+    bignum <class-info> dup \ bignum-mod "outputs" word-prop call class>>
+] unit-test
+
+{ t } [
+    100 random 2^ >bignum
+    [ { bignum } declare 10 /mod ] call nip fixnum?
 ] unit-test

--- a/basis/compiler/tree/propagation/known-words/known-words.factor
+++ b/basis/compiler/tree/propagation/known-words/known-words.factor
@@ -123,14 +123,24 @@ IN: compiler.tree.propagation.known-words
 \ /i [ [ interval/i ] [ may-overflow integer-valued ] binary-op ] each-derived-op
 \ /f [ [ interval/f ] [ float-valued ] binary-op ] each-derived-op
 
-\ mod [ [ interval-mod ] [ real-valued ] binary-op ] each-derived-op
+\ mod [ interval-mod ] [ real-valued ] binary-op
+\ fmod [ interval-mod ] [ real-valued ] binary-op
+\ mod-integer-integer [ interval-mod ] [ integer-valued ] binary-op
+\ bignum-mod [ interval-mod ] [ integer-valued ] binary-op
+\ fixnum-mod [ interval-mod ] [ fixnum-valued ] binary-op
+\ mod-fixnum-integer [ interval-mod ] [ integer-valued ] binary-op
+\ mod-integer-fixnum [ interval-mod ] [ integer-valued ] binary-op
+
 \ rem [ [ interval-rem ] [ may-overflow real-valued ] binary-op ] each-derived-op
 
-{ /mod fixnum/mod } [
-    \ /i \ mod
-    [ "outputs" word-prop ] bi@
-    '[ _ _ 2bi ] "outputs" set-word-prop
-] each
+! /mod is the combination of /i and mod, fixnum/mod of /i and fixnum-mod
+\ /mod
+\ /i \ mod [ "outputs" word-prop ] bi@
+'[ _ _ 2bi ] "outputs" set-word-prop
+
+\ fixnum/mod
+\ /i \ fixnum-mod [ "outputs" word-prop ] bi@
+'[ _ _ 2bi ] "outputs" set-word-prop
 
 : shift-op-class ( info1 info2 -- newclass )
     [ class>> ] bi@

--- a/basis/compiler/tree/propagation/propagation-tests.factor
+++ b/basis/compiler/tree/propagation/propagation-tests.factor
@@ -21,6 +21,12 @@ IN: compiler.tree.propagation.tests
     ] filter
 ] unit-test
 
+! The value interval should be limited for these.
+{ t t } [
+    [ fixnum>bignum ] final-info first interval>> fixnum-interval =
+    [ fixnum>float ] final-info first interval>> fixnum-interval =
+] unit-test
+
 [ V{ } ] [ [ ] final-classes ] unit-test
 
 [ V{ fixnum } ] [ [ 1 ] final-classes ] unit-test
@@ -745,8 +751,11 @@ MIXIN: empty-mixin
     [ { float } declare 0 eq? ] final-classes
 ] unit-test
 
-[ V{ integer } ] [
+! Here we can know both that 1) mod(integer, fixnum) = fixnum and 2)
+! mod(fixnum, integer) = fixnum
+[ V{ fixnum } V{ fixnum } ] [
     [ { integer fixnum } declare mod ] final-classes
+    [ { fixnum integer } declare mod ] final-classes
 ] unit-test
 
 [ V{ integer } ] [
@@ -770,7 +779,7 @@ MIXIN: empty-mixin
 [ V{ t } ] [
     [ [ 123 bitand ] [ drop f ] if dup [ 0 >= ] [ not ] if ] final-literals
 ] unit-test
-  
+
 [ V{ bignum } ] [
     [ { bignum } declare dup 1 - bitxor ] final-classes
 ] unit-test
@@ -941,7 +950,7 @@ M: tuple-with-read-only-slot clone
 [ V{ fixnum } ] [ [ >bignum 10 mod 2^ ] final-classes ] unit-test
 [ V{ bignum } ] [ [ >bignum 10 bitand ] final-classes ] unit-test
 [ V{ bignum } ] [ [ >bignum 10 >bignum bitand ] final-classes ] unit-test
-[ V{ bignum } ] [ [ >bignum 10 mod ] final-classes ] unit-test
+[ V{ fixnum } ] [ [ >bignum 10 mod ] final-classes ] unit-test
 [ V{ bignum } ] [ [ { fixnum } declare -1 >bignum bitand ] final-classes ] unit-test
 [ V{ bignum } ] [ [ { fixnum } declare -1 >bignum swap bitand ] final-classes ] unit-test
 
@@ -1037,7 +1046,7 @@ M: f derp drop t ;
 : bitand-ratio1 ( x -- y )
     1 swap bitand zero? ;
 
-[ 2+1/2 bitand-ratio0 ] [ no-method? ] must-fail-with 
+[ 2+1/2 bitand-ratio0 ] [ no-method? ] must-fail-with
 [ 2+1/2 bitand-ratio1 ] [ no-method? ] must-fail-with
 
 : shift-test0 ( x -- y )

--- a/basis/compiler/tree/propagation/simple/simple-tests.factor
+++ b/basis/compiler/tree/propagation/simple/simple-tests.factor
@@ -1,0 +1,122 @@
+USING: accessors arrays assocs compiler.tree
+compiler.tree.propagation.constraints compiler.tree.propagation.copy
+compiler.tree.propagation.info compiler.tree.propagation.simple kernel math
+math.intervals math.private namespaces sequences system tools.test words ;
+IN: compiler.tree.propagation.simple.tests
+
+: fixnum-value-infos ( -- infos )
+    {
+        H{
+            {
+                1
+                T{ value-info-state
+                   { class fixnum }
+                   { interval
+                     T{ interval
+                        { from { 56977 t } }
+                        { to { 56977 t } }
+                     }
+                   }
+                   { literal 56977 }
+                   { literal? t }
+                }
+            }
+            {
+                2
+                T{ value-info-state
+                   { class fixnum }
+                   { interval
+                     T{ interval
+                        { from { 8098 t } }
+                        { to { 8098 t } }
+                     }
+                   }
+                   { literal 8098 }
+                   { literal? t }
+                }
+            }
+        }
+    } ;
+
+: object-value-infos ( -- infos )
+    {
+        H{
+            {
+                1
+                T{ value-info-state
+                   { class object }
+                   { interval full-interval }
+                }
+            }
+            {
+                2
+                T{ value-info-state
+                   { class object }
+                   { interval full-interval }
+                }
+            }
+        }
+    } ;
+
+: setup-value-infos ( value-infos -- )
+    value-infos set
+    H{ { 1 1 } { 2 2 } { 3 3 } } copies set ;
+
+: #call-fixnum* ( -- node )
+    T{ #call { word fixnum* } { in-d V{ 1 2 } } { out-d { 3 } } } ;
+
+: #call-fixnum/mod ( -- node )
+    T{ #call { word fixnum/mod } { in-d V{ 1 2 } } { out-d { 4 5 } } } ;
+
+{ } [
+    fixnum-value-infos setup-value-infos
+    #call-fixnum* dup word>> "input-classes" word-prop
+    propagate-input-classes
+] unit-test
+
+{ t } [
+    fixnum-value-infos setup-value-infos 1 value-info literal?>>
+] unit-test
+
+{
+    {
+        T{ value-info-state
+           { class fixnum }
+           { interval
+             T{ interval { from { 7 t } } { to { 7 t } } }
+           }
+           { literal 7 }
+           { literal? t }
+        }
+        T{ value-info-state
+           { class fixnum }
+           { interval
+             T{ interval { from { 0 t } } { to { 8097 t } } }
+           }
+        }
+    }
+} [
+    fixnum-value-infos setup-value-infos
+    #call-fixnum/mod dup word>> call-outputs-quot
+] unit-test
+
+! The result of fixnum-mod should always be a fixnum.
+cpu x86.64? [
+    {
+        {
+            T{ value-info-state
+               { class fixnum }
+               { interval
+                 T{ interval
+                    { from { -576460752303423488 t } }
+                    { to { 576460752303423487 t } }
+                 }
+               }
+            }
+        }
+    } [
+        object-value-infos setup-value-infos
+        T{ #call { word fixnum-mod } { in-d V{ 1 2 } } { out-d { 4 } } }
+        dup word>> call-outputs-quot
+    ] unit-test
+] when

--- a/basis/stack-checker/known-words/known-words.factor
+++ b/basis/stack-checker/known-words/known-words.factor
@@ -332,7 +332,7 @@ M: object infer-call* \ call bad-macro-input ;
 \ bignum-bitor { bignum bignum } { bignum } define-primitive \ bignum-bitor make-foldable
 \ bignum-bitxor { bignum bignum } { bignum } define-primitive \ bignum-bitxor make-foldable
 \ bignum-log2 { bignum } { bignum } define-primitive \ bignum-log2 make-foldable
-\ bignum-mod { bignum bignum } { bignum } define-primitive \ bignum-mod make-foldable
+\ bignum-mod { bignum bignum } { integer } define-primitive \ bignum-mod make-foldable
 \ bignum-gcd { bignum bignum } { bignum } define-primitive \ bignum-gcd make-foldable
 \ bignum-shift { bignum fixnum } { bignum } define-primitive \ bignum-shift make-foldable
 \ bignum/i { bignum bignum } { bignum } define-primitive \ bignum/i make-foldable

--- a/basis/stack-checker/known-words/known-words.factor
+++ b/basis/stack-checker/known-words/known-words.factor
@@ -336,7 +336,7 @@ M: object infer-call* \ call bad-macro-input ;
 \ bignum-gcd { bignum bignum } { bignum } define-primitive \ bignum-gcd make-foldable
 \ bignum-shift { bignum fixnum } { bignum } define-primitive \ bignum-shift make-foldable
 \ bignum/i { bignum bignum } { bignum } define-primitive \ bignum/i make-foldable
-\ bignum/mod { bignum bignum } { bignum bignum } define-primitive \ bignum/mod make-foldable
+\ bignum/mod { bignum bignum } { bignum integer } define-primitive \ bignum/mod make-foldable
 \ bignum< { bignum bignum } { object } define-primitive \ bignum< make-foldable
 \ bignum<= { bignum bignum } { object } define-primitive \ bignum<= make-foldable
 \ bignum= { bignum bignum } { object } define-primitive \ bignum= make-foldable

--- a/vm/bignum.cpp
+++ b/vm/bignum.cpp
@@ -369,7 +369,7 @@ FOO_TO_BIGNUM(ulong_long, uint64_t, int64_t, uint64_t)
 /* cannot allocate memory */
 /* bignum_to_cell, fixnum_to_cell, long_long_to_cell, ulong_long_to_cell */
 #define BIGNUM_TO_FOO(name, type, stype, utype)                            \
-  type factor_vm::bignum_to_##name(bignum* bn) {                           \
+  type bignum_to_##name(bignum* bn) {                                      \
     if (BIGNUM_ZERO_P(bn))                                                 \
       return (0);                                                          \
     {                                                                      \

--- a/vm/bignum.hpp
+++ b/vm/bignum.hpp
@@ -42,4 +42,9 @@ enum bignum_comparison {
   bignum_comparison_greater = 1
 };
 
+cell bignum_to_cell(bignum* bn);
+fixnum bignum_to_fixnum(bignum* bn);
+int64_t bignum_to_long_long(bignum* bn);
+uint64_t bignum_to_ulong_long(bignum* bn);
+
 }

--- a/vm/math.cpp
+++ b/vm/math.cpp
@@ -3,6 +3,8 @@
 namespace factor {
 
 cell bignum_maybe_to_fixnum(bignum* bn) {
+  if (BIGNUM_ZERO_P(bn))
+    return tag_fixnum(0);
   fixnum len = BIGNUM_LENGTH(bn);
   bignum_digit_type *digits = BIGNUM_START_PTR(bn);
   if (len == 1 && digits[0] >= fixnum_min && digits[0] <= fixnum_max) {
@@ -143,7 +145,7 @@ void factor_vm::primitive_bignum_divmod() {
   bignum* q, *r;
   bignum_divide(x, y, &q, &r);
   *s1 = tag<bignum>(q);
-  *s0 = tag<bignum>(r);
+  *s0 = bignum_maybe_to_fixnum(r);
 }
 
 void factor_vm::primitive_bignum_mod() {

--- a/vm/math.cpp
+++ b/vm/math.cpp
@@ -2,6 +2,15 @@
 
 namespace factor {
 
+cell bignum_maybe_to_fixnum(bignum* bn) {
+  fixnum len = BIGNUM_LENGTH(bn);
+  bignum_digit_type *digits = BIGNUM_START_PTR(bn);
+  if (len == 1 && digits[0] >= fixnum_min && digits[0] <= fixnum_max) {
+    return tag_fixnum(bignum_to_fixnum(bn));
+  }
+  return tag<bignum>(bn);
+}
+
 void factor_vm::primitive_bignum_to_fixnum() {
   ctx->replace(tag_fixnum(bignum_to_fixnum(untag<bignum>(ctx->peek()))));
 }
@@ -139,7 +148,8 @@ void factor_vm::primitive_bignum_divmod() {
 
 void factor_vm::primitive_bignum_mod() {
   POP_BIGNUMS(x, y);
-  ctx->replace(tag<bignum>(bignum_remainder(x, y)));
+  cell val = bignum_maybe_to_fixnum(bignum_remainder(x, y));
+  ctx->replace(val);
 }
 
 void factor_vm::primitive_bignum_gcd() {

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -232,11 +232,7 @@ struct factor_vm {
                      bignum** remainder);
   bignum* bignum_quotient(bignum* numerator, bignum* denominator);
   bignum* bignum_remainder(bignum* numerator, bignum* denominator);
-  cell bignum_to_cell(bignum* bn);
   fixnum bignum_to_fixnum_strict(bignum* bn);
-  fixnum bignum_to_fixnum(bignum* bn);
-  int64_t bignum_to_long_long(bignum* bn);
-  uint64_t bignum_to_ulong_long(bignum* bn);
   bignum* double_to_bignum(double x);
   int bignum_equal_p_unsigned(bignum* x, bignum* y);
   enum bignum_comparison bignum_compare_unsigned(bignum* x, bignum* y);


### PR DESCRIPTION
Here is a pr I've hacked on to improve propagation for mod type words. It's related #224 and should fix #1230. With the pr:
```factor
IN: [ { integer fixnum } declare /mod fixnum? ] optimized.
[ /i \ t ]
IN: [ { integer } declare 25 /mod 99 * ] optimized.
[ 25 /mod 99 fixnum*fast ]
```
Whereas before:
```factor
IN: [ { integer fixnum } declare /mod fixnum? ] optimized.
[ /mod tag 0 eq? ]
IN: [ { integer } declare 25 /mod 99 * ] optimized.
[
    25 /mod 99 over tag 0 eq?
    [ fixnum* ] [ fixnum>bignum bignum* ] if
]
```
Sadly, some code becomes worse:
```factor
BEFORE:
IN: [ { bignum bignum } declare mod 100 * ] optimized.
[ bignum-mod 100 bignum* ]

AFTER:
IN: [ { bignum bignum } declare mod 100 * ] optimized.
[
    bignum-mod 100 over tag 0 eq?
    [ fixnum* ] [ fixnum>bignum bignum* ] if
]
```
But I'm hoping (without having benchmarked) that the good outweights the bad.

