### PR TITLE
VM: fix bignum>fixnum-strict conversion, previously most-negative-fixnum

### DIFF
--- a/core/math/math-tests.factor
+++ b/core/math/math-tests.factor
@@ -1,4 +1,4 @@
-USING: kernel math namespaces make tools.test ;
+USING: kernel layouts math math.private namespaces make tools.test ;
 IN: math.tests
 
 [ ] [ 5 [ ] times ] unit-test
@@ -96,3 +96,5 @@ IN: math.tests
 
 { t } [ 128 2^ sq 256 2^ = ] unit-test
 { t } [ 128 2^ neg sq 256 2^ = ] unit-test
+
+{ t } [ most-negative-fixnum dup >bignum bignum>fixnum-strict = ] unit-test

--- a/vm/bignum.hpp
+++ b/vm/bignum.hpp
@@ -42,6 +42,7 @@ enum bignum_comparison {
   bignum_comparison_greater = 1
 };
 
+cell bignum_maybe_to_fixnum(bignum* bn);
 cell bignum_to_cell(bignum* bn);
 fixnum bignum_to_fixnum(bignum* bn);
 int64_t bignum_to_long_long(bignum* bn);

--- a/vm/math.cpp
+++ b/vm/math.cpp
@@ -2,17 +2,6 @@
 
 namespace factor {
 
-cell bignum_maybe_to_fixnum(bignum* bn) {
-  if (BIGNUM_ZERO_P(bn))
-    return tag_fixnum(0);
-  fixnum len = BIGNUM_LENGTH(bn);
-  bignum_digit_type *digits = BIGNUM_START_PTR(bn);
-  if (len == 1 && digits[0] >= fixnum_min && digits[0] <= fixnum_max) {
-    return tag_fixnum(bignum_to_fixnum(bn));
-  }
-  return tag<bignum>(bn);
-}
-
 void factor_vm::primitive_bignum_to_fixnum() {
   ctx->replace(tag_fixnum(bignum_to_fixnum(untag<bignum>(ctx->peek()))));
 }


### PR DESCRIPTION
There was a small bug when converting bignums to fixnums. I'm hoping this pr will fix it.