### PR TITLE
cpu.x86: use push and pop when emitting %prologue and %epilogue

### DIFF
--- a/basis/cpu/x86/x86-docs.factor
+++ b/basis/cpu/x86/x86-docs.factor
@@ -61,10 +61,13 @@ HELP: (%slot)
   }
 } ;
 
-
 HELP: decr-stack-reg
 { $values { "n" number } }
-{ $description "Emits an instruction for decrementing the stack register the given number of bytes." } ;
+{ $description "Emits an instruction for decrementing the stack register the given number of bytes. If n is equal to the " { $link cell } " size, then a " { $link PUSH } " instruction is emitted instead because it has a shorter encoding." } ;
+
+HELP: incr-stack-reg
+{ $values { "n" number } }
+{ $description "Emits an instruction for incrementing the stack register the given number of bytes. If n is equal to the " { $link cell } " size, then a " { $link POP } " instruction is emitted instead because it has a shorter encoding." } ;
 
 HELP: load-zone-offset
 { $values { "nursery-ptr" "a register symbol" } }
@@ -106,3 +109,11 @@ HELP: copy-register*
     "0000000533c61fe0: 0f28ca  movaps xmm1, xmm2"
   }
 } ;
+
+ARTICLE: "cpu.x86" "x86 compiler backend"
+"Implementation of " { $vocab-link "cpu.architecture" } " for x86 machines."
+$nl
+{ $link ADD } " and " { $link SUB } " variants:"
+{ $subsections (%inc) decr-stack-reg incr-stack-reg } ;
+
+ABOUT: "cpu.x86"

--- a/basis/cpu/x86/x86-tests.factor
+++ b/basis/cpu/x86/x86-tests.factor
@@ -1,6 +1,7 @@
 USING: compiler.cfg.debugger compiler.cfg.instructions
-compiler.codegen.gc-maps compiler.codegen.relocation compiler.cfg.registers
-cpu.architecture cpu.x86.features kernel kernel.private make math math.libm
+compiler.cfg.registers compiler.codegen.gc-maps
+compiler.codegen.relocation cpu.architecture cpu.x86 cpu.x86.assembler
+cpu.x86.features kernel kernel.private layouts make math math.libm
 namespaces sequences system tools.test ;
 IN: cpu.x86.tests
 
@@ -36,4 +37,15 @@ IN: cpu.x86.tests
 { t } [
     [ D 0 %clear ] B{ } make
     cpu x86.32? B{ 199 6 144 18 0 0 } B{ 73 199 6 144 18 0 0 } ? =
+] unit-test
+
+! %prologue
+{ t } [
+    [ 2 cells %prologue ] B{ } make
+    [ pic-tail-reg PUSH ] B{ } make =
+] unit-test
+
+{ t } [
+    [ 8 cells %prologue ] B{ } make
+    [ stack-reg 7 cells SUB ] B{ } make =
 ] unit-test


### PR DESCRIPTION
A fun trick they use in llvm is to replace some add/sub rsp instructions with push and pops. The latter instructions take one byte each while the former takes four. We can use that too. It reduces the code size by 0.87% :) So, not so much but it was an easy optimization.