### PR TITLE
Compiler fixes again #1308

### DIFF
--- a/basis/bootstrap/image/image-docs.factor
+++ b/basis/bootstrap/image/image-docs.factor
@@ -1,4 +1,5 @@
-USING: help.markup help.syntax io io.files io.pathnames strings ;
+USING: bootstrap.image.private help.markup help.syntax io io.files
+io.pathnames quotations strings words ;
 IN: bootstrap.image
 
 ARTICLE: "bootstrap.image" "Bootstrapping new images"
@@ -13,8 +14,18 @@ $nl
 
 ABOUT: "bootstrap.image"
 
+HELP: architecture
+{ $var-description "Bootstrap architecture name" } ;
+
+HELP: bootstrap-startup-quot
+{ $var-description "This image's startup quotation or " { $link f } ". "} ;
+
+HELP: define-sub-primitive
+{ $values { "quot" quotation } { "word" word } }
+{ $description "Defines a sub primitive by running the quotation which is supposed to output assembler code. The word is then used to call the assembly." } ;
+
 HELP: make-image
 { $values { "arch" string } }
 { $description "Creates a bootstrap image from sources, where " { $snippet "architecture" } " is one of the following:"
-{ $code "x86.32" "unix-x86.64" "windows-x86.64" "linux-ppc" }
+{ $code "\"x86.32\"" "\"unix-x86.64\"" "\"windows-x86.64\"" "\"linux-ppc\"" }
 "The new image file is written to the " { $link resource-path } " and is named " { $snippet "boot." { $emphasis "architecture" } ".image" } "." } ;

--- a/basis/bootstrap/image/image.factor
+++ b/basis/bootstrap/image/image.factor
@@ -149,7 +149,6 @@ SYMBOL: bootstrapping-image
 ! Image output format
 SYMBOL: big-endian
 
-! Bootstrap architecture name
 SYMBOL: architecture
 
 RESET

--- a/basis/compiler/cfg/alias-analysis/alias-analysis.factor
+++ b/basis/compiler/cfg/alias-analysis/alias-analysis.factor
@@ -180,7 +180,7 @@ M: ##box-displaced-alien analyze-aliases
     [ call-next-method ]
     [ base>> heap-ac get merge-acs ] bi ;
 
-M: ##read analyze-aliases
+M: read-insn analyze-aliases
     call-next-method
     dup [ dst>> ] [ insn-slot# ] [ insn-object ] tri
     2dup live-slot dup
@@ -193,7 +193,7 @@ M: ##read analyze-aliases
     #! from?
     live-slot = ;
 
-M:: ##write analyze-aliases ( insn -- insn )
+M:: write-insn analyze-aliases ( insn -- insn )
     insn src>> resolve :> src
     insn insn-slot# :> slot#
     insn insn-object :> vreg

--- a/basis/compiler/cfg/alias-analysis/alias-analysis.factor
+++ b/basis/compiler/cfg/alias-analysis/alias-analysis.factor
@@ -171,7 +171,7 @@ M: insn analyze-aliases ;
 M: vreg-insn analyze-aliases
     def-acs ;
 
-M: ##allocation analyze-aliases
+M: allocation-insn analyze-aliases
     #! A freshly allocated object is distinct from any other
     #! object.
     dup dst>> set-new-ac ;

--- a/basis/compiler/cfg/block-joining/block-joining-docs.factor
+++ b/basis/compiler/cfg/block-joining/block-joining-docs.factor
@@ -3,13 +3,19 @@ IN: compiler.cfg.block-joining
 
 HELP: join-block?
 { $values { "bb" basic-block } { "?" boolean } }
-{ $description "Whether the block can be joined with its predecessor or not." } ;
+{ $description "Whether the block can be joined with its predecessor or not. Two blocks can only be joined if:"
+  { $list
+    "Neither of them are kill blocks"
+    "They have only one predecessor and it has only one successor"
+    "The predecessor has a lower block number"
+  }
+} ;
 
 HELP: join-blocks
 { $values { "cfg" cfg } }
 { $description "A compiler pass when optimizing the cfg." } ;
 
 ARTICLE: "compiler.cfg.block-joining" "Block Joining"
-"Joining blocks that are not calls and are connected by a single CFG edge. This pass does not update " { $link ##phi } " nodes and should therefore only run before stack analysis." ;
+"Joining blocks that are not calls and are connected by a single CFG edge. This pass does not update " { $link ##phi } " nodes and should therefore only run before stack analysis or after ##phi node elimination." ;
 
 ABOUT: "compiler.cfg.block-joining"

--- a/basis/compiler/cfg/block-joining/block-joining-tests.factor
+++ b/basis/compiler/cfg/block-joining/block-joining-tests.factor
@@ -1,0 +1,11 @@
+USING: accessors compiler.cfg.block-joining compiler.cfg.utilities
+kernel tools.test ;
+IN: compiler.cfg.block-joining.tests
+
+{
+    V{ "hello" "there" "B" }
+} [
+    { "there" "B" } 0 insns>block
+    { "hello" "B" } 1 insns>block
+    [ join-instructions ] keep instructions>>
+] unit-test

--- a/basis/compiler/cfg/cfg-docs.factor
+++ b/basis/compiler/cfg/cfg-docs.factor
@@ -20,7 +20,8 @@ HELP: <basic-block>
 
 HELP: <cfg>
 { $values { "word" word } { "label" "label" } { "entry" basic-block } { "cfg" cfg } }
-{ $description "Constructor for " { $link cfg } ". " { $slot "spill-area-size" } " and " { $slot "spill-area-align" } " are set to default values." } ;
+{ $description "Constructor for " { $link cfg } ". " { $slot "spill-area-size" } " and " { $slot "spill-area-align" } " are set to default values." }  ;
+
 
 HELP: cfg
 { $class-description
@@ -33,7 +34,7 @@ HELP: cfg
     { { $slot "frame-pointer?" } { "Whether the cfg needs a frame pointer. Only cfgs generated for " { $link #alien-callback } " nodes does need it." } }
   }
 }
-{ $see-also post-order } ;
+{ $see-also <cfg> post-order } ;
 
 HELP: cfg-changed
 { $values { "cfg" cfg } }

--- a/basis/compiler/cfg/gc-checks/gc-checks-docs.factor
+++ b/basis/compiler/cfg/gc-checks/gc-checks-docs.factor
@@ -33,7 +33,8 @@ HELP: gc-check-offsets
 
 HELP: insert-gc-check?
 { $values { "bb" basic-block } { "?" boolean } }
-{ $description "Whether to insert a gc check in the block or not." } ;
+{ $description "Whether to insert a gc check in the block or not. Only blocks with allocation instructions require gc checks." }
+{ $see-also allocation-insn } ;
 
 HELP: insert-gc-checks
 { $values { "cfg" cfg }  }

--- a/basis/compiler/cfg/gc-checks/gc-checks-tests.factor
+++ b/basis/compiler/cfg/gc-checks/gc-checks-tests.factor
@@ -8,10 +8,9 @@ compiler.cfg.comparisons compiler.test compiler.cfg.utilities ;
 IN: compiler.cfg.gc-checks.tests
 
 ! insert-gc-check?
-{ t } [
-    V{
-        T{ ##inc } T{ ##allot }
-    } 0 insns>block insert-gc-check?
+{ t f } [
+    V{ T{ ##inc } T{ ##allot } } 0 insns>block insert-gc-check?
+    V{ T{ ##call } } 0 insns>block insert-gc-check?
 ] unit-test
 
 ! allocation-size

--- a/basis/compiler/cfg/gc-checks/gc-checks.factor
+++ b/basis/compiler/cfg/gc-checks/gc-checks.factor
@@ -11,7 +11,7 @@ IN: compiler.cfg.gc-checks
 
 : insert-gc-check? ( bb -- ? )
     dup kill-block?>>
-    [ drop f ] [ instructions>> [ ##allocation? ] any? ] if ;
+    [ drop f ] [ instructions>> [ allocation-insn? ] any? ] if ;
 
 : blocks-with-gc ( cfg -- bbs )
     post-order [ insert-gc-check? ] filter ;
@@ -25,7 +25,7 @@ GENERIC# gc-check-offsets* 1 ( call-index seen-allocation? insn n -- call-index 
 M: ##callback-inputs gc-check-offsets* gc-check-here ;
 M: ##phi gc-check-offsets* gc-check-here ;
 M: gc-map-insn gc-check-offsets* gc-check-here ;
-M: ##allocation gc-check-offsets* 3drop t ;
+M: allocation-insn gc-check-offsets* 3drop t ;
 M: insn gc-check-offsets* 2drop ;
 
 : gc-check-offsets ( insns -- seq )
@@ -53,7 +53,7 @@ M: ##box-alien allocation-size* drop 5 cells ;
 M: ##box-displaced-alien allocation-size* drop 5 cells ;
 
 : allocation-size ( insns -- n )
-    [ ##allocation? ] filter
+    [ allocation-insn? ] filter
     [ allocation-size* data-alignment get align ] map-sum ;
 
 : add-gc-checks ( insns-seq -- )

--- a/basis/compiler/cfg/hats/hats-tests.factor
+++ b/basis/compiler/cfg/hats/hats-tests.factor
@@ -1,0 +1,9 @@
+USING: compiler.cfg.hats compiler.cfg.instructions
+compiler.cfg.registers make tools.test ;
+IN: compiler.cfg.hats.tests
+
+{
+    1 V{ T{ ##local-allot { dst 1 } { size 32 } { align 8 } } }
+} [
+    reset-vreg-counter [ 32 8 f ^^local-allot ] V{ } make
+] unit-test

--- a/basis/compiler/cfg/instructions/instructions-docs.factor
+++ b/basis/compiler/cfg/instructions/instructions-docs.factor
@@ -260,6 +260,9 @@ HELP: ##write-barrier
 HELP: alien-call-insn
 { $class-description "Union class of all alien call instructions." } ;
 
+HELP: allocation-insn
+{ $class-description "Union class of all instructions that allocate memory." } ;
+
 HELP: def-is-use-insn
 { $class-description "Union class of instructions that have complex expansions and require that the output registers are not equal to any of the input registers." } ;
 
@@ -336,7 +339,6 @@ $nl
   ##box-long-long
   ##callback-inputs
   ##callback-outputs
-  ##local-allot
   ##unbox
   ##unbox-alien
   ##unbox-any-c-ptr
@@ -348,6 +350,8 @@ $nl
   ##allot
   ##call-gc
   ##check-nursery-branch
+  ##local-allot
+  allocation-insn
   gc-map
   gc-map-insn
   <gc-map>

--- a/basis/compiler/cfg/instructions/instructions.factor
+++ b/basis/compiler/cfg/instructions/instructions.factor
@@ -813,10 +813,10 @@ VREG-INSN: ##reload
 def: dst
 literal: rep src ;
 
-UNION: ##allocation
-##allot
-##box-alien
-##box-displaced-alien ;
+UNION: allocation-insn
+    ##allot
+    ##box-alien
+    ##box-displaced-alien ;
 
 UNION: conditional-branch-insn
 ##compare-branch

--- a/basis/compiler/cfg/instructions/instructions.factor
+++ b/basis/compiler/cfg/instructions/instructions.factor
@@ -834,8 +834,8 @@ UNION: conditional-branch-insn
 ##fixnum-mul ;
 
 ! For alias analysis
-UNION: ##read ##slot ##slot-imm ##vm-field ##alien-global ;
-UNION: ##write ##set-slot ##set-slot-imm ##set-vm-field ;
+UNION: read-insn ##slot ##slot-imm ##vm-field ##alien-global ;
+UNION: write-insn ##set-slot ##set-slot-imm ##set-vm-field ;
 
 UNION: alien-call-insn
     ##alien-assembly

--- a/basis/compiler/cfg/linear-scan/allocation/spilling/spilling-docs.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/spilling/spilling-docs.factor
@@ -1,4 +1,5 @@
-USING: compiler.cfg.linear-scan.allocation.state
+USING: compiler.cfg.linear-scan
+compiler.cfg.linear-scan.allocation.state
 compiler.cfg.linear-scan.live-intervals help.markup help.syntax ;
 IN: compiler.cfg.linear-scan.allocation.spilling
 
@@ -7,16 +8,38 @@ HELP: assign-spill
 { $description "Assigns a spill slot for the live interval." }
 { $see-also assign-spill-slot } ;
 
+HELP: spill-after
+{ $values
+  { "after" live-interval-state }
+  { "after/f" { $link live-interval-state } " or " { $link f } }
+}
+{ $description "If the interval has no more usages after the spill location, then it is the first child of an interval that was split.  We spill the value and let the resolve pass insert a reload later. An interval may be split if it overlaps a " { $link sync-point } "." }
+{ $see-also spill-before } ;
+
+HELP: spill-available
+{ $values { "new" live-interval-state } { "pair" "2-tuple of score and register" } }
+{ $description "A register would become fully available if all active and inactive intervals using it were split and spilled." } ;
+
 HELP: spill-before
 { $values
   { "before" live-interval-state }
   { "before/f" { $link live-interval-state } " or " { $link f } }
 }
-{ $description "If the interval does not have any usages before the spill location, then it is the second child of an interval that was split. We reload the value and let the resolve pass insert a spill later." } ;
+{ $description "If the interval does not have any usages before the spill location, then it is the second child of an interval that was split. We reload the value and let the resolve pass insert a spill later." }
+{ $see-also spill-after } ;
+
+HELP: spill-intersecting
+{ $values { "new" live-interval-state } { "reg" "register" } }
+{ $description "Split and spill all active and inactive intervals which intersect 'new' and use 'reg'." } ;
 
 HELP: spill-intersecting-active
 { $values { "new" live-interval-state } { "reg" "register" } }
 { $description "If there is an active interval using 'reg' (there should be at most one) are split and spilled and removed from the inactive set." } ;
+
+HELP: spill-intersecting-inactive
+{ $values { "new" live-interval-state } { "reg" "register" } }
+{ $description "Any inactive intervals using 'reg' are split and spilled and removed from the inactive set." }
+{ $see-also inactive-intervals } ;
 
 HELP: spill-partially-available
 { $values
@@ -24,3 +47,8 @@ HELP: spill-partially-available
   { "pair" "register availability status" }
 }
 { $description "A register would be available for part of the new interval's lifetime if all active and inactive intervals using that register were split and spilled." } ;
+
+ARTICLE: "compiler.cfg.linear-scan.allocation.spilling" "Spill slot assignment"
+"Words and dynamic variables for assigning spill slots to spilled registers during the " { $link linear-scan } " compiler pass." ;
+
+ABOUT: "compiler.cfg.linear-scan.allocation.spilling"

--- a/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
@@ -107,7 +107,7 @@ ${
 
 ! align-spill-area
 { t } [
-    3 f f { } 0 insns>block <cfg> [ align-spill-area ] keep
+    3 { } insns>cfg [ align-spill-area ] keep
     spill-area-align>> cell =
 ] unit-test
 

--- a/basis/compiler/cfg/linear-scan/assignment/assignment-docs.factor
+++ b/basis/compiler/cfg/linear-scan/assignment/assignment-docs.factor
@@ -30,6 +30,11 @@ HELP: compute-live-in
 { $description "Computes the live in registers for a basic block." }
 { $see-also machine-live-ins } ;
 
+HELP: insert-reload
+{ $values { "live-interval" live-interval-state } }
+{ $description "Inserts a " { $link ##reload } " instruction for a live interval." }
+{ $see-also insert-spill } ;
+
 HELP: machine-edge-live-ins
 { $var-description "Mapping from basic blocks to predecessors to values which are live on a particular incoming edge." } ;
 

--- a/basis/compiler/cfg/linear-scan/assignment/assignment-tests.factor
+++ b/basis/compiler/cfg/linear-scan/assignment/assignment-tests.factor
@@ -31,6 +31,19 @@ IN: compiler.cfg.linear-scan.assignment.tests
     [ assign-registers-in-block ] keep instructions>>
 ] unit-test
 
+! insert-reload
+{
+    { T{ ##reload { dst RAX } { rep int-rep } { src T{ spill-slot } } } }
+} [
+    [
+        T{ live-interval-state
+           { reg RAX }
+           { reload-from T{ spill-slot } }
+           { reload-rep int-rep }
+        } insert-reload
+    ] { } make
+] unit-test
+
 ! insert-spill
 { { T{ ##spill { src RAX } } } } [
     [

--- a/basis/compiler/cfg/linear-scan/linear-scan-docs.factor
+++ b/basis/compiler/cfg/linear-scan/linear-scan-docs.factor
@@ -5,14 +5,17 @@ HELP: admissible-registers
 { $values { "cfg" cfg } { "regs" assoc } }
 { $description "Lists all registers usable by the cfg by register class. In general, that's all registers except the frame pointer register that might be used by the cfg for other purposes." } ;
 
+HELP: allocate-and-assign-registers
+{ $values { "cfg" cfg } }
+{ $description "Allocates and assigns registers and spill slots to SSA values in the cfg." } ;
+
 HELP: linear-scan
 { $values { "cfg" cfg } }
 { $description "Entry point for the linear scan register alloation pass." } ;
 
 ARTICLE: "compiler.cfg.linear-scan" "Linear-scan register allocation"
-"Linear scan to assign physical registers. SSA liveness must have been computed already."
-$nl
-"References:"
+"Linear scan to assign physical registers. SSA liveness must have been computed already. It also spills registers that are live during gc calls."
+{ $heading "References" }
 { $list
   "Linear Scan Register Allocation by Massimiliano Poletto and Vivek Sarkar http://www.cs.ucla.edu/~palsberg/course/cs132/linearscan.pdf"
   "Linear Scan Register Allocation for the Java HotSpot Client Compiler by Christian Wimmer and http://www.ssw.uni-linz.ac.at/Research/Papers/Wimmer04Master/"

--- a/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-docs.factor
+++ b/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-docs.factor
@@ -15,6 +15,11 @@ HELP: block-from
 { $values { "bb" basic-block } { "n" integer } }
 { $description "The instruction number immediately preceeding this block." } ;
 
+HELP: cfg>sync-points
+{ $values { "cfg" cfg } { "sync-points" sequence } }
+{ $description "Creates a sequence of all sync points in the cfg." }
+{ $see-also sync-point } ;
+
 HELP: finish-live-intervals
 { $values { "live-intervals" sequence } }
 { $description "Since live intervals are computed in a backward order, we have to reverse some sequences, and compute the start and end." } ;
@@ -71,9 +76,6 @@ HELP: sync-point
   }
 }
 { $see-also insn } ;
-
-HELP: sync-points
-{ $var-description "Sequence of sync points." } ;
 
 HELP: to
 { $var-description "An integer representing a sequence number equal to the highest number in the currently processed block." } ;

--- a/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-tests.factor
+++ b/basis/compiler/cfg/linear-scan/live-intervals/live-intervals-tests.factor
@@ -1,7 +1,9 @@
-USING: arrays compiler.cfg compiler.cfg.linear-scan.live-intervals
-compiler.cfg.liveness compiler.cfg.registers
-compiler.cfg.ssa.destruction.leaders cpu.architecture kernel namespaces
-sequences tools.test ;
+USING: arrays compiler.cfg compiler.cfg.instructions
+compiler.cfg.linear-scan.live-intervals
+compiler.cfg.linear-scan.numbering compiler.cfg.liveness
+compiler.cfg.registers compiler.cfg.ssa.destruction.leaders
+compiler.cfg.utilities cpu.architecture kernel namespaces sequences
+tools.test ;
 IN: compiler.cfg.linear-scan.live-intervals.tests
 
 ! add-range
@@ -27,6 +29,14 @@ IN: compiler.cfg.linear-scan.live-intervals.tests
 } [
     5 int-rep <live-interval> dup
     { { 10 12 } { 5 10 } } [ first2 rot add-range ] with each
+] unit-test
+
+! cfg>sync-points
+{
+    V{ T{ sync-point { n 0 } } }
+} [
+    V{ T{ ##call-gc } } insns>cfg
+    [ number-instructions ] [ cfg>sync-points ] bi
 ] unit-test
 
 ! handle-live-out
@@ -68,7 +78,7 @@ IN: compiler.cfg.linear-scan.live-intervals.tests
 } [
     -10 from set
     23 to set
-    init-live-intervals
+    H{ } clone live-intervals set
     H{ { 4 4 } { 8 8 } { 9 9 } } leader-map set
     H{ { 4 int-rep } { 8 int-rep } { 9 int-rep } } representations set
     <basic-block> [ H{ { 4 4 } { 8 8 } { 9 9 } } 2array 1array live-outs set ]

--- a/basis/compiler/cfg/liveness/liveness-docs.factor
+++ b/basis/compiler/cfg/liveness/liveness-docs.factor
@@ -1,5 +1,6 @@
 USING: assocs compiler.cfg compiler.cfg.def-use compiler.cfg.instructions
-compiler.cfg.representations help.markup help.syntax kernel ;
+compiler.cfg.representations hash-sets help.markup help.syntax kernel
+sequences ;
 IN: compiler.cfg.liveness
 
 HELP: base-pointers
@@ -16,6 +17,10 @@ HELP: edge-live-ins
 HELP: fill-gc-map
 { $values { "live-set" assoc } { "gc-map" gc-map } }
 { $description "Assigns values to the " { $slot "gc-roots" } " and " { $slot "derived-roots" } " slots of the " { $link gc-map } ". Does nothing if the " { $link select-representations } " pass hasn't ran." } ;
+
+HELP: gc-roots
+{ $values { "live-set" assoc } { "derived-roots" hash-set } { "gc-roots" sequence } }
+{ $description "" } ;
 
 HELP: gen-uses
 { $values { "live-set" assoc } { "insn" insn } }

--- a/basis/compiler/cfg/liveness/liveness-tests.factor
+++ b/basis/compiler/cfg/liveness/liveness-tests.factor
@@ -1,9 +1,9 @@
-USING: accessors compiler.cfg.liveness
-compiler.cfg compiler.cfg.debugger compiler.cfg.instructions
-compiler.cfg.predecessors compiler.cfg.registers
+USING: accessors alien assocs compiler.cfg.comparisons compiler.cfg.liveness
+compiler.cfg compiler.cfg.debugger compiler.cfg.def-use
+compiler.cfg.instructions compiler.cfg.predecessors compiler.cfg.registers
 compiler.cfg.ssa.destruction.leaders compiler.cfg.utilities cpu.architecture
-dlists namespaces sequences kernel tools.test vectors alien math
-compiler.cfg.comparisons cpu.x86.assembler.operands assocs ;
+cpu.x86.assembler.operands dlists math namespaces sequences kernel system
+tools.test vectors ;
 IN: compiler.cfg.liveness.tests
 QUALIFIED: sets
 
@@ -100,6 +100,14 @@ QUALIFIED: sets
     { T{ ##tagged>integer f 30 15 } } 0 insns>block block>cfg compute-live-sets
     30 lookup-base-pointer
 ] unit-test
+
+cpu x86.64? [
+    { f } [
+        H{ } base-pointers set
+        H{ { 123 T{ ##peek { dst RCX } { loc D 1 } { insn# 6 } } } } insns set
+        123 lookup-base-pointer
+    ] unit-test
+] when
 
 ! lookup-base-pointer*
 { f } [

--- a/basis/compiler/cfg/representations/selection/selection-docs.factor
+++ b/basis/compiler/cfg/representations/selection/selection-docs.factor
@@ -1,0 +1,19 @@
+USING: help.markup help.syntax math sequences ;
+IN: compiler.cfg.representations.selection
+
+HELP: costs
+{ $var-description "Maps vreg to representation to cost." } ;
+
+HELP: increase-cost
+{ $values { "rep" "representation symbol" } { "scc" "?" } { "factor" integer } }
+{ $description "Increase cost of keeping vreg in rep, making a choice of rep less likely. If the rep is not in the cost alist, it means this representation is prohibited." } ;
+
+HELP: init-costs
+{ $description "Initialize cost as 0 for each possibility." } ;
+
+HELP: minimize-costs
+{ $values { "costs" sequence } { "representations" sequence } }
+{ $description "For every vreg, compute preferred representation, that minimizes costs." } ;
+
+HELP: tagged-vregs
+{ $var-description "Vregs which must be tagged at the definition site because there is at least one usage that is not int-rep. If all usages are int-rep it is safe to untag at the definition site." } ;

--- a/basis/compiler/cfg/representations/selection/selection-tests.factor
+++ b/basis/compiler/cfg/representations/selection/selection-tests.factor
@@ -1,0 +1,9 @@
+USING: compiler.cfg.instructions
+compiler.cfg.representations.selection tools.test ;
+IN: compiler.cfg.representations.selection.tests
+
+{ t t f } [
+    T{ ##load-integer } peephole-optimizable?
+    T{ ##shr-imm } peephole-optimizable?
+    T{ ##call } peephole-optimizable?
+] unit-test

--- a/basis/compiler/cfg/representations/selection/selection.factor
+++ b/basis/compiler/cfg/representations/selection/selection.factor
@@ -12,9 +12,6 @@ FROM: assocs => change-at ;
 FROM: namespaces => set ;
 IN: compiler.cfg.representations.selection
 
-! vregs which must be tagged at the definition site because
-! there is at least one usage that is not int-rep. If all usages
-! are int-rep it is safe to untag at the definition site.
 SYMBOL: tagged-vregs
 
 SYMBOL: vreg-reps
@@ -62,17 +59,12 @@ SYMBOL: possibilities
 ! For every vreg, compute the cost of keeping it in every possible
 ! representation.
 
-! Cost map maps vreg to representation to cost.
 SYMBOL: costs
 
 : init-costs ( -- )
-    ! Initialize cost as 0 for each possibility.
     possibilities get [ [ 0 ] H{ } map>assoc ] assoc-map costs set ;
 
 : increase-cost ( rep scc factor -- )
-    ! Increase cost of keeping vreg in rep, making a choice of rep less
-    ! likely. If the rep is not in the cost alist, it means this
-    ! representation is prohibited.
     [ costs get at 2dup key? ] dip
     '[ [ current-loop-nesting 10^ _ * + ] change-at ] [ 2drop ] if ;
 
@@ -137,7 +129,6 @@ M: vreg-insn compute-insn-costs
         [ [ compute-insn-costs ] each-non-phi ] bi
     ] each-basic-block ;
 
-! For every vreg, compute preferred representation, that minimizes costs.
 : minimize-costs ( costs -- representations )
     [ nip assoc-empty? ] assoc-reject
     [ >alist alist-min first ] assoc-map ;

--- a/basis/compiler/cfg/representations/selection/selection.factor
+++ b/basis/compiler/cfg/representations/selection/selection.factor
@@ -88,39 +88,37 @@ UNION: inert-arithmetic-tag-untag-insn
 ##sub-imm ;
 
 UNION: inert-bitwise-tag-untag-insn
-##and-imm
-##or-imm
-##xor-imm ;
+    ##and-imm
+    ##or-imm
+    ##xor-imm ;
 
-GENERIC: has-peephole-opts? ( insn -- ? )
-
-M: insn has-peephole-opts? drop f ;
-M: ##load-integer has-peephole-opts? drop t ;
-M: ##load-reference has-peephole-opts? drop t ;
-M: ##neg has-peephole-opts? drop t ;
-M: ##not has-peephole-opts? drop t ;
-M: inert-tag-untag-insn has-peephole-opts? drop t ;
-M: inert-arithmetic-tag-untag-insn has-peephole-opts? drop t ;
-M: inert-bitwise-tag-untag-insn has-peephole-opts? drop t ;
-M: ##mul-imm has-peephole-opts? drop t ;
-M: ##shl-imm has-peephole-opts? drop t ;
-M: ##shr-imm has-peephole-opts? drop t ;
-M: ##sar-imm has-peephole-opts? drop t ;
-M: ##compare-integer-imm has-peephole-opts? drop t ;
-M: ##compare-integer has-peephole-opts? drop t ;
-M: ##compare-integer-imm-branch has-peephole-opts? drop t ;
-M: ##compare-integer-branch has-peephole-opts? drop t ;
-M: ##test-imm has-peephole-opts? drop t ;
-M: ##test has-peephole-opts? drop t ;
-M: ##test-imm-branch has-peephole-opts? drop t ;
-M: ##test-branch has-peephole-opts? drop t ;
+UNION: peephole-optimizable
+    ##load-integer
+    ##load-reference
+    ##neg
+    ##not
+    inert-tag-untag-insn
+    inert-arithmetic-tag-untag-insn
+    inert-bitwise-tag-untag-insn
+    ##mul-imm
+    ##shl-imm
+    ##shr-imm
+    ##sar-imm
+    ##compare-integer-imm
+    ##compare-integer
+    ##compare-integer-imm-branch
+    ##compare-integer-branch
+    ##test-imm
+    ##test
+    ##test-imm-branch
+    ##test-branch ;
 
 GENERIC: compute-insn-costs ( insn -- )
 
 M: insn compute-insn-costs drop ;
 
 M: vreg-insn compute-insn-costs
-    dup has-peephole-opts? 2 5 ? '[ _ increase-costs ] each-rep ;
+    dup peephole-optimizable? 2 5 ? '[ _ increase-costs ] each-rep ;
 
 : compute-costs ( cfg -- )
     init-costs

--- a/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-docs.factor
@@ -1,9 +1,14 @@
-USING: compiler.cfg.instructions compiler.cfg.ssa.interference
+USING: compiler.cfg compiler.cfg.instructions
+compiler.cfg.ssa.destruction.leaders compiler.cfg.ssa.interference
 help.markup help.syntax kernel make sequences ;
 IN: compiler.cfg.ssa.destruction.coalescing
 
 HELP: class-element-map
 { $var-description "Maps leaders to equivalence class elements which are sequences of " { $link vreg-info } " instances." } ;
+
+HELP: coalesce-cfg
+{ $values { "cfg" cfg } }
+{ $description "In this step, " { $link leader-map } " info is calculated." } ;
 
 HELP: coalesce-elements
 { $values { "merged" "??" } { "follower" "vreg" } { "leader" "vreg" } }

--- a/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-docs.factor
@@ -14,13 +14,22 @@ HELP: coalesce-elements
 { $values { "merged" "??" } { "follower" "vreg" } { "leader" "vreg" } }
 { $description "Delete follower's class, and set leaders's class to merged." } ;
 
-HELP: coalesce-insn
+HELP: coalesce-now
 { $values { "insn" insn } }
-{ $description "Generic word supposed to be called in a " { $link make } " context which generates a list of eliminatable vreg copies. The word either eliminates copies immediately in case of " { $link ##phi } " and " { $link ##tagged>integer } " instructions or appends copies to the make sequence so that they are handled later by " { $link coalesce-cfg } "." } ;
+{ $description "Generic word which finds copy pairs in instructions and tries to eliminate them directly." }
+{ $see-also coalesce-later } ;
+
+HELP: coalesce-later
+{ $values { "insn" insn } }
+{ $description "Generic word supposed to be called in a " { $link make } " context which generates a list of eliminatable vreg copies. The copies are batched up and then eliminated by " { $link try-eliminate-copies } "." } ;
 
 HELP: coalesce-vregs
 { $values { "merged" "??" } { "follower" "vreg" } { "leader" "vreg" } }
 { $description "Sets 'leader' as the leader of 'follower'." } ;
+
+HELP: eliminatable-copy?
+{ $values { "vreg1" "vreg" } { "vreg2" "vreg" } }
+{ $description "Determines if a vreg copy can be eliminated. It can be eliminated if the vregs have the same register class and same representation size." } ;
 
 HELP: try-eliminate-copy
 { $values { "follower" "vreg" } { "leader" "vreg" } { "must?" boolean } }
@@ -33,7 +42,7 @@ HELP: try-eliminate-copies
 { $see-also try-eliminate-copy } ;
 
 ARTICLE: "compiler.cfg.ssa.destruction.coalescing" "Vreg Coalescing"
-"This compiler pass eliminates redundant vreg copies."
+"This compiler pass eliminates redundant vreg copies. Coalescing occurs in two steps. First all redundant copies in all " { $link ##tagged>integer } " and " { $link ##phi } " instructions are handled. Then those in other instructions like " { $link vreg-insn } ", " { $link ##copy } " and " { $link ##parallel-copy } "."
 $nl
 "Main entry point:"
 { $subsections coalesce-cfg }

--- a/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-tests.factor
+++ b/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-tests.factor
@@ -50,15 +50,15 @@ IN: compiler.cfg.ssa.destruction.coalescing.tests
            { size 24 }
            { temp 303 }
         }
-    } insns>cfg initial-leaders
+    } initial-leaders
 ] unit-test
 
 ! init-coalescing
 {
     H{ { 118 118 } }
 } [
-    { T{ ##phi { dst 118 } { inputs H{ { 4 120 } { 2 119 } } } } } insns>cfg
-    dup compute-defs init-coalescing
+    { T{ ##phi { dst 118 } { inputs H{ { 4 120 } { 2 119 } } } } }
+    [ insns>cfg compute-defs ] [ init-coalescing ] bi
     leader-map get
 ] unit-test
 
@@ -67,16 +67,16 @@ IN: compiler.cfg.ssa.destruction.coalescing.tests
     10 10 f try-eliminate-copy
 ] unit-test
 
-! coalesce-insn
+! coalesce-later
 { V{ { 2 1 } } } [
     [
-        T{ ##copy { src 1 } { dst 2 } { rep int-rep } } coalesce-insn
+        T{ ##copy { src 1 } { dst 2 } { rep int-rep } } coalesce-later
     ] V{ } make
 ] unit-test
 
 { V{ { 3 4 } { 7 8 } } } [
     [
-        T{ ##parallel-copy { values V{ { 3 4 } { 7 8 } } } } coalesce-insn
+        T{ ##parallel-copy { values V{ { 3 4 } { 7 8 } } } } coalesce-later
     ] V{ } make
 ] unit-test
 
@@ -92,7 +92,7 @@ IN: compiler.cfg.ssa.destruction.coalescing.tests
     10 [
         { 2286 2287 2288 } sets:unique leader-map set
         2286 make-phi-inputs ##phi new-insn
-        coalesce-insn
+        coalesce-now
         2286 leader
     ] replicate all-equal?
 ] unit-test

--- a/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-tests.factor
+++ b/basis/compiler/cfg/ssa/destruction/coalescing/coalescing-tests.factor
@@ -1,10 +1,24 @@
 USING: assocs compiler.cfg.def-use compiler.cfg.instructions
-compiler.cfg.ssa.destruction.coalescing
+compiler.cfg.registers compiler.cfg.ssa.destruction.coalescing
 compiler.cfg.ssa.destruction.leaders compiler.cfg.ssa.interference
 compiler.cfg.utilities cpu.architecture grouping kernel make
 namespaces random sequences tools.test ;
 QUALIFIED: sets
 IN: compiler.cfg.ssa.destruction.coalescing.tests
+
+! eliminatable-copy?
+{ { f t t f } } [
+    H{
+        { 45 double-2-rep }
+        { 46 double-rep }
+        { 47 double-rep }
+        { 100 double-rep }
+        { 20 tagged-rep }
+        { 30 int-rep }
+    } representations set
+    { { 45 46 } { 47 100 } { 20 30 } { 30 100 } }
+    [ first2 eliminatable-copy? ] map
+] unit-test
 
 ! initial-class-elements
 {

--- a/basis/compiler/cfg/ssa/destruction/coalescing/coalescing.factor
+++ b/basis/compiler/cfg/ssa/destruction/coalescing/coalescing.factor
@@ -14,14 +14,6 @@ SYMBOL: class-element-map
 : value-of ( vreg -- value )
     dup insn-of dup ##tagged>integer? [ nip src>> ] [ drop ] if ;
 
-: init-coalescing ( -- )
-    defs get
-    [ keys unique leader-map set ]
-    [
-        [ [ dup dup value-of ] dip <vreg-info> 1array ] assoc-map
-        class-element-map set
-    ] bi ;
-
 : coalesce-elements ( merged follower leader -- )
     class-element-map get [ delete-at ] [ set-at ] bi-curry bi* ;
 
@@ -50,15 +42,12 @@ M: insn coalesce-insn drop ;
 M: alien-call-insn coalesce-insn drop ;
 
 M: vreg-insn coalesce-insn
-    [ temp-vregs [ leader-map get conjoin ] each ]
-    [
-        [ defs-vregs ] [ uses-vregs ] bi
-        2dup [ empty? not ] both? [
-            [ first ] bi@
-            2dup [ rep-of reg-class-of ] bi@ eq?
-            [ 2array , ] [ 2drop ] if
-        ] [ 2drop ] if
-    ] bi ;
+    [ defs-vregs ] [ uses-vregs ] bi
+    2dup [ empty? not ] both? [
+        [ first ] bi@
+        2dup [ rep-of reg-class-of ] bi@ eq?
+        [ 2array , ] [ 2drop ] if
+    ] [ 2drop ] if ;
 
 M: ##copy coalesce-insn
     [ dst>> ] [ src>> ] bi 2array , ;
@@ -73,7 +62,17 @@ M: ##phi coalesce-insn
     [ dst>> ] [ inputs>> values ] bi zip-scalar
     natural-sort t try-eliminate-copies ;
 
+: initial-leaders ( cfg -- leaders )
+    cfg>insns [ [ defs-vregs ] [ temp-vregs ] bi append ] map concat unique ;
+
+: initial-class-elements ( -- class-elements )
+    defs get [ [ dup dup value-of ] dip <vreg-info> 1array ] assoc-map ;
+
+: init-coalescing ( cfg -- )
+    initial-leaders leader-map set
+    initial-class-elements class-element-map set ;
+
 : coalesce-cfg ( cfg -- )
-    init-coalescing
+    dup init-coalescing
     cfg>insns-rpo [ [ coalesce-insn ] each ] V{ } make
     f try-eliminate-copies ;

--- a/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/destruction-docs.factor
@@ -10,7 +10,7 @@ HELP: cleanup-cfg
 ARTICLE: "compiler.cfg.ssa.destruction" "SSA Destruction"
 "Because of the design of the register allocator, this pass has three peculiar properties."
 { $list
-  "Instead of renaming vreg usages in the CFG, a map from vregs to canonical representatives is computed. This allows the register allocator to use the original SSA names to get reaching definitions."
+  { "Instead of renaming vreg usages in the CFG, a map from vregs to canonical representatives is computed. This allows the register allocator to use the original SSA names to get reaching definitions. See " { $link leader-map } "." }
   { "Useless " { $link ##copy } " instructions, and all " { $link ##phi } " instructions, are eliminated, so the register allocator does not have to remove any redundant operations." }
   { "This pass computes live sets and fills out the " { $slot "gc-roots" } " slots of GC maps with " { $vocab-link "compiler.cfg.liveness" } ", so the linear scan register allocator does not need to compute liveness again." }
 }

--- a/basis/compiler/cfg/ssa/destruction/leaders/leaders-docs.factor
+++ b/basis/compiler/cfg/ssa/destruction/leaders/leaders-docs.factor
@@ -6,7 +6,7 @@ HELP: ?leader
 { $description "The leader of the vreg or the register itself if it has no other leader." } ;
 
 HELP: leader-map
-{ $var-description "A map from vregs to canonical representatives due to coalescing done by SSA destruction. Used by liveness analysis and the register allocator, so we can use the original SSA names to get certain info (reaching definitions, representations). By default, each vreg is its own leader." }
+{ $var-description "A map from vregs to canonical representatives due to coalescing done by SSA destruction. Used by liveness analysis and the register allocator, so we can use the original SSA names to get certain info (reaching definitions, representations). By default, each vreg is its own leader. The data is computed in the " { $vocab-link "compiler.cfg.ssa.destruction" } " compiler pass." }
 { $see-also init-coalescing } ;
 
 ARTICLE: "compiler.cfg.ssa.destruction.leaders" "Leader book-keeping" "This vocab defines words for getting the leaders of vregs." ;

--- a/basis/compiler/cfg/ssa/interference/interference-docs.factor
+++ b/basis/compiler/cfg/ssa/interference/interference-docs.factor
@@ -1,11 +1,16 @@
-USING: help.markup help.syntax ;
+USING: compiler.cfg help.markup help.syntax sequences ;
 IN: compiler.cfg.ssa.interference
+
+HELP: sets-interfere?
+{ $values { "seq1" sequence } { "seq2" sequence } }
+{ $description "Checks if two sets consisting of " { $link vreg-info } " instances interfere with each other. If they interfere, then copies can not be eliminated." } ;
 
 HELP: vreg-info
 { $class-description
   "Slots:"
   { $table
     { { $slot "vreg" } { "The vreg the vreg-info is the info for." } }
+    { { $slot "bb" } { "The " { $link basic-block } " in which the vreg is defined." } }
   }
 } ;
 

--- a/basis/compiler/cfg/stack-frame/stack-frame-docs.factor
+++ b/basis/compiler/cfg/stack-frame/stack-frame-docs.factor
@@ -1,4 +1,4 @@
-USING: cpu.x86 help.markup help.syntax layouts math ;
+USING: compiler.cfg.instructions cpu.x86 help.markup help.syntax layouts math ;
 IN: compiler.cfg.stack-frame
 
 HELP: stack-frame
@@ -25,7 +25,7 @@ HELP: stack-frame
 
 HELP: (stack-frame-size)
 { $values { "stack-frame" stack-frame } { "n" integer } }
-{ $description "Base stack frame size, without padding and alignment." } ;
+{ $description "Base stack frame size, without padding and alignment. If the size is zero, then no " { $link ##epilogue } " and " { $link ##prologue } " needs to be emitted for the word." } ;
 
 HELP: spill-offset
 { $values { "n" integer } { "offset" integer } }

--- a/basis/compiler/codegen/labels/labels-docs.factor
+++ b/basis/compiler/codegen/labels/labels-docs.factor
@@ -1,5 +1,14 @@
-USING: compiler.codegen.relocation help.markup help.syntax strings ;
+USING: byte-arrays compiler.codegen.relocation help.markup help.syntax
+strings ;
 IN: compiler.codegen.labels
+
+HELP: binary-literal-table
+{ $var-description "A relocation table used during code generation to keep track of binary relocations. Binary literals are stored at the end of the generated assembly code on the code heap." } ;
+
+HELP: rel-binary-literal
+{ $values { "literal" byte-array } { "class" "relocation class" } }
+{ $description "Adds a binary literal to the relocation table." }
+{ $see-also binary-literal-table } ;
 
 HELP: define-label
 { $values { "name" string } }

--- a/basis/compiler/codegen/relocation/relocation-docs.factor
+++ b/basis/compiler/codegen/relocation/relocation-docs.factor
@@ -20,6 +20,10 @@ HELP: add-literal
 HELP: init-relocation
 { $description "Initializes the dynamic variables related to code relocation." } ;
 
+HELP: rel-decks-offset
+{ $values { "class" "a relocation class" } }
+{ $description "Adds a decks offset relocation. It is used for marking cards when emitting write barriers." } ;
+
 HELP: rel-safepoint
 { $values { "class" "a relocation class" } }
 { $description "Adds a safe point to the " { $link relocation-table } " for the current code offset. This word is used by the " { $link %safepoint } " generator." } ;
@@ -42,6 +46,9 @@ HELP: compiled-offset
 } ;
 
 ARTICLE: "compiler.codegen.relocation" "Relocatable VM objects"
-"The " { $vocab-link "compiler.codegen.relocation" } " deals with assigning memory addresses to VM objects, such as the card table. Those objects have different addresses during each execution which is why they are \"relocatable\". The vocab is shared by the optimizing and non-optimizing compiler." ;
+"The " { $vocab-link "compiler.codegen.relocation" } " deals with assigning memory addresses to VM objects, such as the card table. Those objects have different addresses during each execution which is why they are \"relocatable\". The vocab is shared by the optimizing and non-optimizing compiler."
+$nl
+"Adding relocations:"
+{ $subsections add-relocation rel-decks-offset rel-safepoint } ;
 
 ABOUT: "compiler.codegen.relocation"

--- a/basis/compiler/tree/def-use/def-use-docs.factor
+++ b/basis/compiler/tree/def-use/def-use-docs.factor
@@ -1,0 +1,11 @@
+USING: compiler.tree help.markup help.syntax sequences ;
+IN: compiler.tree.def-use
+
+HELP: node-defs-values
+{ $values { "node" node } { "values" sequence } }
+{ $description "The sequence of values the node introduces." } ;
+
+ARTICLE: "compiler.tree.def-use" "Def/use chain construction"
+"Def/use chain construction" ;
+
+ABOUT: "compiler.tree.def-use"

--- a/basis/compiler/tree/escape-analysis/allocations/allocations-docs.factor
+++ b/basis/compiler/tree/escape-analysis/allocations/allocations-docs.factor
@@ -1,0 +1,28 @@
+USING: compiler.tree disjoint-sets help.markup help.syntax ;
+IN: compiler.tree.escape-analysis.allocations
+
+HELP: allocations
+{ $var-description "A map from values to one of the following:"
+  { $list
+    "f -- initial status, assigned to values we have not seen yet; may potentially become an allocation later"
+    "a sequence of values -- potentially unboxed tuple allocations"
+    "t -- not allocated in this procedure, can never be unboxed"
+  }
+} ;
+
+HELP: compute-escaping-allocations
+{ $description "Compute which tuples escape" } ;
+
+HELP: escaping-values
+{ $var-description "We track escaping values with a " { $link disjoint-set } "." } ;
+
+HELP: slot-access
+{ $var-description "We track slot access to connect constructor inputs with accessor outputs." } ;
+
+HELP: value-classes
+{ $var-description "A map from values to classes. Only for " { $link #introduce } " outputs." } ;
+
+ARTICLE: "compiler.tree.escape-analysis.allocations" "Tracking memory allocations"
+"Tracks memory allocations and unboxes those which can be determined never escapes." ;
+
+ABOUT: "compiler.tree.escape-analysis.allocations"

--- a/basis/compiler/tree/escape-analysis/allocations/allocations.factor
+++ b/basis/compiler/tree/escape-analysis/allocations/allocations.factor
@@ -5,18 +5,12 @@ namespaces sequences stack-checker.values ;
 FROM: namespaces => set ;
 IN: compiler.tree.escape-analysis.allocations
 
-! A map from values to classes. Only for #introduce outputs
 SYMBOL: value-classes
 
 : value-class ( value -- class ) value-classes get at ;
 
 : set-value-class ( class value -- ) value-classes get set-at ;
 
-! A map from values to one of the following:
-! - f -- initial status, assigned to values we have not seen yet;
-!        may potentially become an allocation later
-! - a sequence of values -- potentially unboxed tuple allocations
-! - t -- not allocated in this procedure, can never be unboxed
 SYMBOL: allocations
 
 : (allocation) ( -- allocations )
@@ -31,8 +25,6 @@ SYMBOL: allocations
 : record-allocations ( allocations values -- )
     (allocation) '[ _ set-at ] 2each ;
 
-! We track slot access to connect constructor inputs with
-! accessor outputs.
 SYMBOL: slot-accesses
 
 TUPLE: slot-access slot# value ;
@@ -42,7 +34,6 @@ C: <slot-access> slot-access
 : record-slot-access ( out slot# in -- )
     <slot-access> swap slot-accesses get set-at ;
 
-! We track escaping values with a disjoint set.
 SYMBOL: escaping-values
 
 SYMBOL: +escaping+
@@ -126,7 +117,6 @@ DEFER: copy-value
         [ nth swap copy-value ]
     } cond ;
 
-! Compute which tuples escape
 SYMBOL: escaping-allocations
 
 : compute-escaping-allocations ( -- )

--- a/basis/compiler/tree/escape-analysis/check/check-docs.factor
+++ b/basis/compiler/tree/escape-analysis/check/check-docs.factor
@@ -1,0 +1,11 @@
+USING: help.markup help.syntax kernel sequences ;
+IN: compiler.tree.escape-analysis.check
+
+HELP: run-escape-analysis?
+{ $values { "nodes" sequence } { "?" boolean } }
+{ $description "Whether to run escape analysis on the nodes or not." } ;
+
+ARTICLE: "compiler.tree.escape-analysis.check"
+"Skipping escape analysis pass for code which does not allocate" ;
+
+ABOUT: "compiler.tree.escape-analysis.check"

--- a/basis/compiler/tree/escape-analysis/escape-analysis-docs.factor
+++ b/basis/compiler/tree/escape-analysis/escape-analysis-docs.factor
@@ -1,0 +1,7 @@
+USING: help.markup help.syntax ;
+IN: compiler.tree.escape-analysis
+
+ARTICLE: "compiler.tree.escape-analysis" "Escape analysis for tuple unboxing"
+"This pass must run after propagation" ;
+
+ABOUT: "compiler.tree.escape-analysis"

--- a/basis/compiler/tree/escape-analysis/escape-analysis.factor
+++ b/basis/compiler/tree/escape-analysis/escape-analysis.factor
@@ -9,9 +9,7 @@ USE: compiler.tree.escape-analysis.simple
 
 IN: compiler.tree.escape-analysis
 
-! This pass must run after propagation
-
-: escape-analysis ( node -- node )
+: escape-analysis ( nodes -- nodes )
     init-escaping-values
     H{ } clone allocations set
     H{ } clone slot-accesses set

--- a/basis/compiler/tree/escape-analysis/nodes/nodes-docs.factor
+++ b/basis/compiler/tree/escape-analysis/nodes/nodes-docs.factor
@@ -1,0 +1,11 @@
+USING: compiler.tree help.markup help.syntax ;
+IN: compiler.tree.escape-analysis.nodes
+
+HELP: escape-analysis*
+{ $values { "node" node } }
+{ $description "Performs escape analysis for one SSA node." } ;
+
+ARTICLE: "compiler.tree.escape-analysis.nodes"
+"Per-node dispatch for escape analysis" ;
+
+ABOUT: "compiler.tree.escape-analysis.nodes"

--- a/basis/compiler/tree/propagation/copy/copy-docs.factor
+++ b/basis/compiler/tree/propagation/copy/copy-docs.factor
@@ -1,0 +1,19 @@
+USING: help.markup help.syntax math sequences ;
+IN: compiler.tree.propagation.copy
+
+HELP: compute-phi-equiv
+{ $values { "inputs" sequence } { "outputs" sequence } }
+{ $description "An output is a copy of every input if all inputs are copies of the same original value." } ;
+
+HELP: copies
+{ $var-description "Mapping from values to their canonical leader" } ;
+
+HELP: resolve-copy
+{ $values { "copy" integer } { "val" integer } }
+{ $description "Gets the original definer of this SSA value." } ;
+
+ARTICLE: "compiler.tree.propagation.copy"
+"Copy propagation"
+"Two values are copy-equivalent if they are always identical at run-time (\"DS\" relation). This is just a weak form of value numbering." ;
+
+ABOUT: "compiler.tree.propagation.copy"

--- a/basis/compiler/tree/propagation/copy/copy.factor
+++ b/basis/compiler/tree/propagation/copy/copy.factor
@@ -5,11 +5,6 @@ compiler.utilities grouping kernel namespaces sequences sets
 stack-checker.branches ;
 IN: compiler.tree.propagation.copy
 
-! Two values are copy-equivalent if they are always identical
-! at run-time ("DS" relation). This is just a weak form of
-! value numbering.
-
-! Mapping from values to their canonical leader
 SYMBOL: copies
 
 : resolve-copy ( copy -- val ) copies get compress-path ;
@@ -31,8 +26,6 @@ GENERIC: compute-copy-equiv* ( node -- )
 M: #renaming compute-copy-equiv* inputs/outputs are-copies-of ;
 
 : compute-phi-equiv ( inputs outputs -- )
-    #! An output is a copy of every input if all inputs are
-    #! copies of the same original value.
     [
         swap remove-bottom resolve-copies
         dup [ f ] [ all-equal? ] if-empty

--- a/basis/compiler/tree/propagation/info/info-docs.factor
+++ b/basis/compiler/tree/propagation/info/info-docs.factor
@@ -1,4 +1,4 @@
-USING: compiler.tree help.markup help.syntax sequences ;
+USING: compiler.tree help.markup help.syntax math sequences ;
 IN: compiler.tree.propagation.info
 
 HELP: node-input-infos
@@ -9,6 +9,10 @@ HELP: node-output-infos
 { $values { "node" node } { "seq" sequence } }
 { $description "Lists the value infos for the output variables of an SSA tree node." } ;
 
+HELP: value-info
+{ $values { "value" integer } { "info" value-info-state } }
+{ $description "Gets the value info for the given SSA value. If none is found then a null empty interval is returned." } ;
+
 HELP: value-info-state
 { $class-description "Represents constraints the compiler knows about the input and output variables to an SSA tree node. It has the following slots:"
   { $table
@@ -18,7 +22,18 @@ HELP: value-info-state
     { { $slot "literal?" } { "Whether the value of the variable is known at compile-time or not." } }
     { { $slot "slots" } { "If the value is a literal tuple or fixed length type, then slots is a " { $link sequence } " of " { $link value-info-state } " encoding what is known about its slots at compile-time." } }
   }
+  "Don't mutate value infos you receive, always construct new ones. We don't declare the slots read-only to allow cloning followed by writing, and to simplify constructors."
 } ;
 
 HELP: value-infos
 { $var-description "Assoc stack of current value --> info mapping" } ;
+
+ARTICLE: "compiler.tree.propagation.info" "Value info data type and operations"
+"Querying words:"
+{ $subsections
+  node-input-infos
+  node-output-infos
+  value-info
+} ;
+
+ABOUT: "compiler.tree.propagation.info"

--- a/basis/compiler/tree/propagation/info/info.factor
+++ b/basis/compiler/tree/propagation/info/info.factor
@@ -22,10 +22,6 @@ M: ratio eql? over ratio? [ = ] [ 2drop f ] if ;
 M: float eql? over float? [ [ double>bits ] same? ] [ 2drop f ] if ;
 M: complex eql? over complex? [ = ] [ 2drop f ] if ;
 
-! Value info represents a set of objects. Don't mutate value infos
-! you receive, always construct new ones. We don't declare the
-! slots read-only to allow cloning followed by writing, and to
-! simplify constructors.
 TUPLE: value-info-state
 class
 interval

--- a/basis/compiler/tree/propagation/inlining/inlining-docs.factor
+++ b/basis/compiler/tree/propagation/inlining/inlining-docs.factor
@@ -1,10 +1,6 @@
 USING: compiler.tree help.markup help.syntax kernel quotations words ;
 IN: compiler.tree.propagation.inlining
 
-HELP: custom-inlining?
-{ $values { "word" word } { "quot/f" "a quotation or " { $link f } } }
-{ $description "Returns the custom inlining " { $link quotation } " for a word if it has one." } ;
-
 HELP: (do-inlining)
 { $values { "#call" #call } { "word" word } { "?" boolean } }
 { $description
@@ -12,6 +8,18 @@ HELP: (do-inlining)
   $nl
   "If the generic was defined in an outer compilation unit, then it doesn't have a definition yet; the definition is built at the end of the compilation unit. We do not attempt inlining at this stage since the stack discipline is not finalized yet, so dispatch# might return an out of bounds value. This case comes up if a parsing word calls the compiler at parse time (doing so is discouraged, but it should still work.)"
 } ;
+
+HELP: custom-inlining?
+{ $values { "word" word } { "quot/f" "a quotation or " { $link f } } }
+{ $description "Returns the custom inlining " { $link quotation } " for a word if it has one." } ;
+
+HELP: do-inlining
+{ $values { "#call" #call } { "word" word } { "?" boolean } }
+{ $description "Performs inlining of the word in the #call node. If there's a custom inlining hook, it is permitted to return f, which means that we try the normal inlining heuristic." } ;
+
+HELP: inline-math-method
+{ $values { "#call" #call } { "word" word } { "?" boolean } }
+{ $description "Inlines a generic math word." } ;
 
 ARTICLE: "compiler.tree.propagation.inlining" "Method inlining and dispatch elimination"
 "Splicing nodes:"

--- a/basis/compiler/tree/propagation/inlining/inlining.factor
+++ b/basis/compiler/tree/propagation/inlining/inlining.factor
@@ -113,9 +113,6 @@ SYMBOL: history
     } cond ;
 
 : do-inlining ( #call word -- ? )
-    #! Note the logic here: if there's a custom inlining hook,
-    #! it is permitted to return f, which means that we try the
-    #! normal inlining heuristic.
     [
         dup custom-inlining? [ 2dup inline-custom ] [ f ] if
         [ 2drop t ] [ (do-inlining) ] if

--- a/basis/compiler/tree/propagation/nodes/nodes-docs.factor
+++ b/basis/compiler/tree/propagation/nodes/nodes-docs.factor
@@ -4,3 +4,7 @@ IN: compiler.tree.propagation.nodes
 HELP: annotate-node
 { $values { "node" node } }
 { $description "Initializes the info slot for SSA tree nodes that have it." } ;
+
+HELP: propagate-around
+{ $values { "node" node } }
+{ $description "Performs value propagation for an SSA node." } ;

--- a/basis/compiler/tree/propagation/simple/simple-docs.factor
+++ b/basis/compiler/tree/propagation/simple/simple-docs.factor
@@ -1,0 +1,18 @@
+USING: compiler.tree compiler.tree.propagation.info help.markup
+help.syntax quotations sequences words ;
+IN: compiler.tree.propagation.simple
+
+HELP: call-outputs-quot
+{ $values { "#call" #call } { "word" word } { "infos" sequence } }
+{ $description "Calls the word's \"outputs\" " { $link quotation } " to determine the output sequence of value infos, given the input sequence." } ;
+
+HELP: output-value-infos
+{ $values { "#call" #call } { "word" word } { "infos" sequence } }
+{ $description "Computes what the output value infos for a #call node should be." }
+{ $see-also value-info-state } ;
+
+ARTICLE: "compiler.tree.propagation.simple"
+"Propagation for straight-line code"
+"Propagation for straight-line code" ;
+
+ABOUT: "compiler.tree.propagation.simple"

--- a/basis/compiler/tree/propagation/simple/simple.factor
+++ b/basis/compiler/tree/propagation/simple/simple.factor
@@ -11,8 +11,6 @@ continuations fry kernel sequences stack-checker.dependencies
 words ;
 IN: compiler.tree.propagation.simple
 
-! Propagation for straight-line code.
-
 M: #introduce propagate-before
     out-d>> [ object-info swap set-value-info ] each ;
 
@@ -46,7 +44,7 @@ M: anonymous-intersection add-depends-on-class
 M: #declare propagate-before
     #! We need to force the caller word to recompile when the
     #! classes mentioned in the declaration are redefined, since
-    #! now we're making assumptions but their definitions.
+    #! now we're making assumptions about their definitions.
     declaration>> [
         [ add-depends-on-class ]
         [ <class-info> swap refine-value-info ]

--- a/basis/compiler/tree/tree-docs.factor
+++ b/basis/compiler/tree/tree-docs.factor
@@ -1,5 +1,6 @@
-USING: assocs help.markup help.syntax kernel quotations sequences
-stack-checker.alien stack-checker.values stack-checker.visitor words ;
+USING: assocs help.markup help.syntax kernel kernel.private quotations
+sequences stack-checker.alien stack-checker.values
+stack-checker.visitor words ;
 IN: compiler.tree
 
 HELP: node
@@ -20,9 +21,14 @@ HELP: #call
     { { $slot "word" } { "The " { $link word } " to call." } }
     { { $slot "in-d" } { "Sequence of input variables to the call. The items are ordered from top to bottom of the stack." } }
     { { $slot "out-d" } { "Output values of the call." } }
-    { { $slot "info" } { "An assoc that contains various annotations for the words input and output values. It is set during the propagation pass of the optimizer." } }
+    { { $slot "method" } { "If the called word is generic and inlined here, then 'method' contains the inlined " { $link quotation } "." } }
+    { { $slot "body" } { "If the called word is generic and inlined, then 'body' is a sequence of SSA nodes built from the inlined method." } }
+    { { $slot "info" } { "If the called word is generic and inlined, then the info slot contains an assoc of value infos for the body of the inlined generic. It is set during the propagation pass of the optimizer." } }
   }
 } ;
+
+HELP: #declare
+{ $class-description "SSA tree node emitted when " { $link declare } " declarations are encountered." } ;
 
 HELP: #introduce
 { $class-description "SSA tree node that puts an input value from the \"outside\" on the stack. It is used to \"introduce\" data stack parameter whenever they are needed. It has the following slots:"
@@ -58,3 +64,13 @@ HELP: #if
 HELP: node,
 { $values { "node" node } }
 { $description "Emits a node to the " { $link stack-visitor } " variable." } ;
+
+ARTICLE: "compiler.tree" "High-level optimizer operating on lexical tree SSA IR"
+"Node types:"
+{ $subsections
+  #call
+  #declare
+  #shuffle
+} ;
+
+ABOUT: "compiler.tree"

--- a/basis/compiler/tree/tree.factor
+++ b/basis/compiler/tree/tree.factor
@@ -4,8 +4,6 @@ USING: accessors arrays assocs kernel namespaces sequences
 stack-checker.visitor vectors ;
 IN: compiler.tree
 
-! High-level tree SSA form.
-
 TUPLE: node < identity-tuple ;
 
 TUPLE: #introduce < node out-d ;

--- a/basis/compiler/tree/tuple-unboxing/tuple-unboxing-docs.factor
+++ b/basis/compiler/tree/tuple-unboxing/tuple-unboxing-docs.factor
@@ -1,0 +1,7 @@
+USING: compiler.tree.escape-analysis help.markup help.syntax ;
+IN: compiler.tree.tuple-unboxing
+
+ARTICLE: "compiler.tree.tuple-unboxing" "Tuple unboxing"
+"This pass must run after " { $link escape-analysis } "." ;
+
+ABOUT: "compiler.tree.tuple-unboxing"

--- a/basis/compiler/tree/tuple-unboxing/tuple-unboxing.factor
+++ b/basis/compiler/tree/tuple-unboxing/tuple-unboxing.factor
@@ -9,8 +9,6 @@ sequences slots.private stack-checker.branches
 stack-checker.values vectors ;
 IN: compiler.tree.tuple-unboxing
 
-! This pass must run after escape analysis
-
 GENERIC: unbox-tuples* ( node -- node/nodes )
 
 : unbox-output? ( node -- values )

--- a/basis/cpu/architecture/architecture-docs.factor
+++ b/basis/cpu/architecture/architecture-docs.factor
@@ -151,6 +151,10 @@ HELP: %copy
 { $description "Emits code copying a value from a register, arbitrary memory location or " { $link spill-slot } " to a destination." }
 { $examples { $unchecked-example $[ ex-%copy ] } } ;
 
+HELP: %dispatch
+{ $values { "src" "a register symbol" } { "temp" "a register symbol" } }
+{ $description "Code emitter for the " { $link ##dispatch } " instruction." } ;
+
 HELP: %horizontal-add-vector
 { $values
   { "dst" "destination register symbol" }
@@ -197,7 +201,8 @@ HELP: %local-allot
   { "align" "alignment" }
   { "offset" "where to allocate the data, relative to the stack register" }
 }
-{ $description "Emits machine code for stack \"allocating\" a chunk of memory. No memory is really allocated and instead a pointer to it is just put in the destination register." } ;
+{ $description "Emits machine code for stack \"allocating\" a chunk of memory. No memory is really allocated and instead a pointer to it is just put in the destination register." }
+{ $see-also ##local-allot } ;
 
 HELP: %replace-imm
 { $values

--- a/basis/cpu/x86/x86.factor
+++ b/basis/cpu/x86/x86.factor
@@ -647,26 +647,29 @@ HOOK: %prepare-var-args cpu ( -- )
 
 HOOK: %cleanup cpu ( n -- )
 
-:: emit-alien-insn ( reg-inputs stack-inputs reg-outputs dead-outputs cleanup stack-size quot -- )
+M:: x86 %alien-assembly ( reg-inputs
+                         stack-inputs
+                         reg-outputs
+                         dead-outputs
+                         cleanup
+                         stack-size
+                         quot -- )
     stack-inputs [ first3 %store-stack-param ] each
     reg-inputs [ first3 %store-reg-param ] each
     %prepare-var-args
-    quot call
+    quot call( -- )
     cleanup %cleanup
     reg-outputs [ first3 %load-reg-param ] each
-    dead-outputs [ first2 %discard-reg-param ] each ; inline
+    dead-outputs [ first2 %discard-reg-param ] each ;
 
 M: x86 %alien-invoke ( reg-inputs stack-inputs reg-outputs dead-outputs cleanup stack-size symbols dll gc-map -- )
-    '[ _ _ _ %c-invoke ] emit-alien-insn ;
+    '[ _ _ _ %c-invoke ] %alien-assembly ;
 
 M:: x86 %alien-indirect ( src reg-inputs stack-inputs reg-outputs dead-outputs cleanup stack-size gc-map -- )
     reg-inputs stack-inputs reg-outputs dead-outputs cleanup stack-size [
         src ?spill-slot CALL
         gc-map gc-map-here
-    ] emit-alien-insn ;
-
-M: x86 %alien-assembly ( reg-inputs stack-inputs reg-outputs dead-outputs cleanup stack-size quot -- )
-    '[ _ call( -- ) ] emit-alien-insn ;
+    ] %alien-assembly ;
 
 HOOK: %begin-callback cpu ( -- )
 

--- a/basis/io/ports/ports-docs.factor
+++ b/basis/io/ports/ports-docs.factor
@@ -41,6 +41,10 @@ ABOUT: "io.ports"
 HELP: port
 { $class-description "Instances of this class present a blocking stream interface on top of an underlying non-blocking I/O system, giving the illusion of blocking by yielding the thread which is waiting for input or output." } ;
 
+HELP: shutdown
+{ $values { "handle" "a port handle" } }
+{ $description "Called when a port is being disposed." } ;
+
 HELP: input-port
 { $class-description "The class of ports implementing the input stream protocol." } ;
 

--- a/basis/math/partial-dispatch/partial-dispatch-docs.factor
+++ b/basis/math/partial-dispatch/partial-dispatch-docs.factor
@@ -1,0 +1,16 @@
+USING: help.markup help.syntax math sequences words ;
+IN: math.partial-dispatch
+
+HELP: define-integer-ops
+{ $values { "word" word } { "fix-word" word } { "big-word" word } }
+{ $description "Defines an integral arithmetic operation. 'word' is the generic word, 'fix-word' the word to dispatch on if the last argument is a " { $link fixnum } " and 'big-word' thew ord if it is a " { $link bignum } "." } ;
+
+HELP: derived-ops
+{ $values { "word" word } { "words" sequence } }
+{ $description "Lists all derived words of the given word, including the word itself." } ;
+
+ARTICLE: "math.partial-dispatch"
+"Partially-dispatched math operations, used by the compiler"
+"Partially-dispatched math operations" ;
+
+ABOUT: "math.partial-dispatch"

--- a/basis/math/vectors/simd/intrinsics/intrinsics-docs.factor
+++ b/basis/math/vectors/simd/intrinsics/intrinsics-docs.factor
@@ -1,0 +1,11 @@
+USING: help.markup help.syntax sequences ;
+IN: math.vectors.simd.intrinsics
+
+HELP: (simd-select)
+{ $description "Word which implements " { $link nth } " for SIMD vectors." }
+{ $examples
+  { $unchecked-example
+    "float-4{ 3 4 9 1 } underlying>> 2 float-4-rep (simd-select)"
+    "9.0"
+  }
+} ;

--- a/basis/math/vectors/simd/simd-tests.factor
+++ b/basis/math/vectors/simd/simd-tests.factor
@@ -761,3 +761,13 @@ STRUCT: simd-struct
     [ 123 assert= ]
     bi*
 ] unit-test
+
+! #1308
+: test-1308 ( a b -- c )
+    { double-4 double-4 } declare
+    v+ dup first 10 > [ first ] [ third ] if 1array ;
+
+! Before the fix, this evaluated to an uninitialized value.
+{ 33.0 } [
+    double-4{ 2 20 30 40 } double-4{ 2 4 3 2 } test-1308 first
+] unit-test

--- a/basis/threads/threads-docs.factor
+++ b/basis/threads/threads-docs.factor
@@ -73,10 +73,34 @@ ABOUT: "threads"
 HELP: thread
 { $class-description "A thread. The slots are as follows:"
     { $list
-        { { $snippet "id" } " - a unique identifier assigned to each thread." }
-        { { $snippet "name" } " - the name passed to " { $link spawn } "." }
-        { { $snippet "quot" } " - the initial quotation passed to " { $link spawn } "." }
-        { { $snippet "status" } " - a " { $link string } " indicating what the thread is waiting for, or " { $link f } ". This slot is intended to be used for debugging purposes." }
+      {
+          { $snippet "id" }
+          " - a unique identifier assigned to each thread."
+      }
+      {
+          { $snippet "exit-handler" }
+          " - a " { $link quotation } " run when the thread is being stopped."
+      }
+      {
+          { $snippet "name" }
+          " - the name passed to " { $link spawn } "."
+      }
+      {
+          { $snippet "quot" }
+          " - the initial quotation passed to " { $link spawn } "."
+      }
+      {
+          { $snippet "runnable" }
+          " - whether the thread is runnable. Initially it is, " { $link f } "."
+      }
+      {
+          { $snippet "status" }
+          " - a " { $link string } " indicating what the thread is waiting for, or " { $link f } ". This slot is intended to be used for debugging purposes."
+      }
+      {
+          { $snippet "context" }
+          " - a " { $link box } " holding an alien pointer to the threads " { $link context } " object."
+      }
     }
 } ;
 

--- a/core/compiler/units/units-docs.factor
+++ b/core/compiler/units/units-docs.factor
@@ -1,5 +1,5 @@
 USING: definitions help.markup help.syntax kernel parser
-quotations source-files stack-checker.errors words ;
+quotations sequences source-files stack-checker.errors words ;
 IN: compiler.units
 
 ARTICLE: "compilation-units-internals" "Compilation units internals"
@@ -72,6 +72,10 @@ HELP: with-nested-compilation-unit
 HELP: recompile
 { $values { "words" "a sequence of words" } { "alist" "an association list mapping words to compiled definitions" } }
 { $contract "Internal word which compiles words. Called at the end of " { $link with-compilation-unit } "." } ;
+
+HELP: to-recompile
+{ $values { "words" sequence } }
+{ $description "Sequence of words that will be recompiled by the compilation unit." } ;
 
 HELP: no-compilation-unit
 { $values { "word" word } }

--- a/core/kernel/kernel-docs.factor
+++ b/core/kernel/kernel-docs.factor
@@ -63,6 +63,9 @@ HELP: build
 { $values { "n" integer } }
 { $description "The current build number. Factor increments this number whenever a new boot image is created." } ;
 
+HELP: leaf-signal-handler
+{ $description "A word called by the VM when a VM error occurs." } ;
+
 HELP: hashcode*
 { $values { "depth" integer } { "obj" object } { "code" fixnum } }
 { $contract "Outputs the hashcode of an object. The hashcode operation must satisfy the following properties:"


### PR DESCRIPTION
This pr should fix the #1308 bug. A lot of the commits are just docs I wrote or some small refactorings. The bug appears to have been that it made a vreg the leader of another as long as they had the same register class. But they also need to have the same representation size. 