### PR TITLE
compiler.cfg.utilities: make it so block>cfg initializes spill-area-a…

### DIFF
--- a/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
+++ b/basis/compiler/cfg/linear-scan/allocation/state/state-tests.factor
@@ -106,9 +106,9 @@ ${
 ] unit-test
 
 ! align-spill-area
-{ t } [
+${ cell } [
     3 { } insns>cfg [ align-spill-area ] keep
-    spill-area-align>> cell =
+    spill-area-align>>
 ] unit-test
 
 ! inactive-intervals-for

--- a/basis/compiler/cfg/utilities/utilities.factor
+++ b/basis/compiler/cfg/utilities/utilities.factor
@@ -6,7 +6,7 @@ kernel locals make math namespaces sequences sets ;
 IN: compiler.cfg.utilities
 
 : block>cfg ( bb -- cfg )
-    cfg new swap >>entry ;
+    f f rot <cfg> ;
 
 : insns>block ( insns n -- bb )
     <basic-block> swap >>number swap V{ } like >>instructions ;


### PR DESCRIPTION
This fixes the test failure!