### PR TITLE
Serialize

### DIFF
--- a/basis/serialize/serialize-tests.factor
+++ b/basis/serialize/serialize-tests.factor
@@ -5,7 +5,7 @@ USING: tools.test kernel serialize io io.streams.byte-array
 alien arrays byte-arrays bit-arrays specialized-arrays
 sequences math prettyprint parser classes math.constants
 io.encodings.binary random assocs serialize.private alien.c-types
-combinators.short-circuit ;
+combinators.short-circuit literals ;
 SPECIALIZED-ARRAY: double
 IN: serialize.tests
 
@@ -107,3 +107,25 @@ CONSTANT: objects
     bytes>object
     dup keys first eq?
 ] unit-test
+
+! Changed the serialization of numbers in [2^1008;2^1024[
+! check backwards compatibility
+${ 1008 2^ } [ B{
+    255 1 127 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0 0 0 0 0 0
+} binary [ deserialize-cell ] with-byte-reader ] unit-test
+
+${ 1024 2^ 1 - } [ B{
+    255 1 128 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255 255 255 255 255
+    255 255 255 255 255 255 255 255 255 255 255
+} binary [ deserialize-cell ] with-byte-reader ] unit-test

--- a/basis/serialize/serialize-tests.factor
+++ b/basis/serialize/serialize-tests.factor
@@ -9,10 +9,13 @@ combinators.short-circuit ;
 SPECIALIZED-ARRAY: double
 IN: serialize.tests
 
-: test-serialize-cell ( a -- ? )
-    2^ random dup
+: (test-serialize-cell) ( n -- ? )
+    dup
     binary [ serialize-cell ] with-byte-writer
     binary [ deserialize-cell ] with-byte-reader = ;
+
+: test-serialize-cell ( a -- ? )
+    2^ random (test-serialize-cell) ;
 
 { t } [
     100 [
@@ -23,6 +26,11 @@ IN: serialize.tests
             [  4 [ 400 *  test-serialize-cell ] all-integers? ]
             [  4 [ 4000 * test-serialize-cell ] all-integers? ]
         } 0&&
+    ] all-integers?
+] unit-test
+
+{ t } [ 2000 [
+        2^ 3 [ 1 - + (test-serialize-cell) ] with all-integers?
     ] all-integers?
 ] unit-test
 


### PR DESCRIPTION
Hi,
this "fixes" the serialize vocab which would emit numbers in range [2^1008; 2^1024[ with 131 bytes, but they can be emitted in 129 bytes for free (and the comments pretended it dit). It's also backwards compatible in the sense that old serialized values still deserialize as the correct answer.