### PR TITLE
authors, use utf-8 to fix Björn's name

### DIFF
--- a/extra/pcre/authors.txt
+++ b/extra/pcre/authors.txt
@@ -1,1 +1,1 @@
-Björn Lindqvist
+BjÃ¶rn Lindqvist


### PR DESCRIPTION
I noticed @bjourne 's name had an unprintable character on http://docs.factorcode.org/content/article-vocab-authors.html. Factor is pretty good for working with non ascii characters so we need to fix it ! :)

It was written in latin1 in ./extra/pcre/authors.txt, this commit changes it back to utf-8.