### PR TITLE
curses.listener: fix, need stream-write1 after changes to stream-bl

### DIFF
--- a/extra/curses/listener/listener.factor
+++ b/extra/curses/listener/listener.factor
@@ -48,6 +48,9 @@ M: curses-listener-stream stream-readln
 M: curses-listener-stream stream-write
     drop cwrite ;
 
+M: curses-listener-stream stream-write1
+    drop addch ;
+
 M: curses-listener-stream stream-flush
     drop crefresh ;
 


### PR DESCRIPTION
a simple fix for curses.listener which wouldn't start at all because it didn't implement stream-write1. It is now needed since 708224644775f8777b273118b810db5463d5d47c