### PR TITLE
Vm cleanups 2015 aug part2

### DIFF
--- a/basis/stack-checker/known-words/known-words.factor
+++ b/basis/stack-checker/known-words/known-words.factor
@@ -346,7 +346,6 @@ M: object infer-call* \ call bad-macro-input ;
 \ bits>double { integer } { float } define-primitive \ bits>double make-foldable
 \ bits>float { integer } { float } define-primitive \ bits>float make-foldable
 \ both-fixnums? { object object } { object } define-primitive
-\ get-callstack { } { callstack } define-primitive \ get-callstack make-flushable
 \ callstack-bounds { } { alien alien } define-primitive \ callstack-bounds make-flushable
 \ callstack-for { c-ptr } { callstack } define-primitive \ callstack make-flushable
 \ callstack>array { callstack } { array } define-primitive \ callstack>array make-flushable
@@ -359,7 +358,6 @@ M: object infer-call* \ call bad-macro-input ;
 \ current-callback { } { fixnum } define-primitive \ current-callback make-flushable
 \ (callback-room) { } { byte-array } define-primitive \ (callback-room) make-flushable
 \ (data-room) { } { byte-array } define-primitive \ (data-room) make-flushable
-\ get-datastack { } { array } define-primitive \ get-datastack make-flushable
 \ datastack-for { c-ptr } { array } define-primitive \ datastack-for make-flushable
 \ die { } { } define-primitive
 \ disable-gc-events { } { object } define-primitive
@@ -438,7 +436,6 @@ M: object infer-call* \ call bad-macro-input ;
 \ resize-array { integer array } { array } define-primitive
 \ resize-byte-array { integer byte-array } { byte-array } define-primitive
 \ resize-string { integer string } { string } define-primitive
-\ get-retainstack { } { array } define-primitive \ get-retainstack make-flushable
 \ retainstack-for { c-ptr } { array } define-primitive \ retainstack-for make-flushable
 \ set-alien-cell { c-ptr c-ptr integer } { } define-primitive
 \ set-alien-double { float c-ptr integer } { } define-primitive

--- a/basis/threads/threads.factor
+++ b/basis/threads/threads.factor
@@ -13,16 +13,11 @@ PRIMITIVE: (set-context-and-delete) ( obj context -- * )
 PRIMITIVE: (sleep) ( nanos -- )
 PRIMITIVE: (start-context) ( obj quot -- obj' )
 PRIMITIVE: (start-context-and-delete) ( obj quot -- * )
-PRIMITIVE: callstack-for ( context -- array )
+
 PRIMITIVE: context-object-for ( n context -- obj )
-PRIMITIVE: datastack-for ( context -- array )
-PRIMITIVE: retainstack-for ( context -- array )
 
 ! Wrap sub-primitives; we don't want them inlined into callers
 ! since their behavior depends on what frames are on the callstack
-: context ( -- context )
-    CONTEXT-OBJ-CONTEXT context-object ; inline
-
 : set-context ( obj context -- obj' )
     (set-context) ; inline
 

--- a/basis/vm/vm-tests.factor
+++ b/basis/vm/vm-tests.factor
@@ -1,4 +1,4 @@
-USING: accessors classes.struct kernel math math.order threads.private
+USING: accessors classes.struct kernel kernel.private math math.order
 tools.test ;
 QUALIFIED: vm
 IN: vm.tests

--- a/core/bootstrap/primitives.factor
+++ b/core/bootstrap/primitives.factor
@@ -451,11 +451,12 @@ tuple
     { "fwrite" "io.streams.c" "primitive_fwrite" ( data length alien -- ) }
     { "(clone)" "kernel" "primitive_clone" ( obj -- newobj ) }
     { "<wrapper>" "kernel" "primitive_wrapper" ( obj -- wrapper ) }
-    { "get-callstack" "kernel" "primitive_callstack" ( -- callstack ) }
+
     { "callstack>array" "kernel" "primitive_callstack_to_array" ( callstack -- array ) }
-    { "get-datastack" "kernel" "primitive_datastack" ( -- array ) }
     { "die" "kernel" "primitive_die" ( -- ) }
-    { "get-retainstack" "kernel" "primitive_retainstack" ( -- array ) }
+    { "callstack-for" "kernel.private" "primitive_callstack_for" ( context -- array ) }
+    { "datastack-for" "kernel.private" "primitive_datastack_for" ( context -- array ) }
+    { "retainstack-for" "kernel.private" "primitive_retainstack_for" ( context -- array ) }
     { "(identity-hashcode)" "kernel.private" "primitive_identity_hashcode" ( obj -- code ) }
     { "become" "kernel.private" "primitive_become" ( old new -- ) }
     { "callstack-bounds" "kernel.private" "primitive_callstack_bounds" ( -- start end ) }
@@ -542,10 +543,7 @@ tuple
     { "(exit)" "system" "primitive_exit" ( n -- * ) }
     { "nano-count" "system" "primitive_nano_count" ( -- ns ) }
     { "(sleep)" "threads.private" "primitive_sleep" ( nanos -- ) }
-    { "callstack-for" "threads.private" "primitive_callstack_for" ( context -- array ) }
     { "context-object-for" "threads.private" "primitive_context_object_for" ( n context -- obj ) }
-    { "datastack-for" "threads.private" "primitive_datastack_for" ( context -- array ) }
-    { "retainstack-for" "threads.private" "primitive_retainstack_for" ( context -- array ) }
     { "dispatch-stats" "tools.dispatch.private" "primitive_dispatch_stats" ( -- stats ) }
     { "reset-dispatch-stats" "tools.dispatch.private" "primitive_reset_dispatch_stats" ( -- ) }
     { "word-code" "words" "primitive_word_code" ( word -- start end ) }

--- a/core/kernel/kernel.factor
+++ b/core/kernel/kernel.factor
@@ -28,9 +28,6 @@ PRIMITIVE: 4dup ( w x y z -- w x y z w x y z )
 PRIMITIVE: (clone) ( obj -- newobj )
 PRIMITIVE: eq? ( obj1 obj2 -- ? )
 PRIMITIVE: <wrapper> ( obj -- wrapper )
-PRIMITIVE: get-datastack ( -- array )
-PRIMITIVE: get-callstack ( -- callstack )
-PRIMITIVE: get-retainstack ( -- array )
 PRIMITIVE: die ( -- )
 PRIMITIVE: callstack>array ( callstack -- array )
 
@@ -453,4 +450,20 @@ CONSTANT: ERROR-FP-TRAP 18
 CONSTANT: ERROR-INTERRUPT 19
 CONSTANT: ERROR-CALLBACK-SPACE-OVERFLOW 20
 
+PRIMITIVE: callstack-for ( context -- array )
+PRIMITIVE: retainstack-for ( context -- array )
+PRIMITIVE: datastack-for ( context -- array )
+
+: context ( -- context )
+    CONTEXT-OBJ-CONTEXT context-object ; inline
+
 PRIVATE>
+
+: get-callstack ( -- callstack )
+    context callstack-for ; inline
+
+: get-datastack ( -- array )
+    context datastack-for ; inline
+
+: get-retainstack ( -- array )
+    context retainstack-for ; inline

--- a/vm/alien.cpp
+++ b/vm/alien.cpp
@@ -47,8 +47,8 @@ cell factor_vm::allot_alien(cell delegate_, cell displacement) {
 }
 
 /* Allocates memory */
-cell factor_vm::allot_alien(void* address) {
-  return allot_alien(false_object, (cell)address);
+cell factor_vm::allot_alien(cell address) {
+  return allot_alien(false_object, address);
 }
 
 /* make an alien pointing at an offset of another alien */

--- a/vm/callbacks.cpp
+++ b/vm/callbacks.cpp
@@ -125,7 +125,7 @@ void factor_vm::primitive_callback() {
 
   cell func = callbacks->add(w.value(), return_rewind)->entry_point();
   CODE_TO_FUNCTION_POINTER_CALLBACK(this, func);
-  ctx->push(allot_alien((void*)func));
+  ctx->push(allot_alien(func));
 }
 
 void factor_vm::primitive_free_callback() {

--- a/vm/callstack.cpp
+++ b/vm/callstack.cpp
@@ -41,9 +41,6 @@ cell factor_vm::capture_callstack(context* ctx) {
 }
 
 /* Allocates memory (capture_callstack) */
-void factor_vm::primitive_callstack() { ctx->push(capture_callstack(ctx)); }
-
-/* Allocates memory (capture_callstack) */
 void factor_vm::primitive_callstack_for() {
   context* other_ctx = (context*)pinned_alien_offset(ctx->peek());
   ctx->replace(capture_callstack(other_ctx));

--- a/vm/callstack.cpp
+++ b/vm/callstack.cpp
@@ -114,8 +114,8 @@ void factor_vm::primitive_set_innermost_stack_frame_quotation() {
 
 /* Allocates memory (allot_alien) */
 void factor_vm::primitive_callstack_bounds() {
-  ctx->push(allot_alien((void*)ctx->callstack_seg->start));
-  ctx->push(allot_alien((void*)ctx->callstack_seg->end));
+  ctx->push(allot_alien(ctx->callstack_seg->start));
+  ctx->push(allot_alien(ctx->callstack_seg->end));
 }
 
 }

--- a/vm/code_blocks.cpp
+++ b/vm/code_blocks.cpp
@@ -149,31 +149,27 @@ cell factor_vm::compute_dlsym_address(array* parameters, cell index) {
 
   dll* d = (to_boolean(library) ? untag<dll>(library) : NULL);
 
-  void* undefined_symbol = (void*)factor::undefined_symbol;
+  cell undefined_symbol = (cell)factor::undefined_symbol;
   undefined_symbol = FUNCTION_CODE_POINTER(undefined_symbol);
   if (d != NULL && !d->handle)
-    return (cell)undefined_symbol;
+    return undefined_symbol;
 
   switch (tagged<object>(symbol).type()) {
     case BYTE_ARRAY_TYPE: {
       symbol_char* name = alien_offset(symbol);
-      void* sym = ffi_dlsym(d, name);
-
-      if (sym)
-        return (cell)sym;
-      else
-        return (cell)undefined_symbol;
+      cell sym = ffi_dlsym(d, name);
+      return sym ? sym : undefined_symbol;
     }
     case ARRAY_TYPE: {
       array* names = untag<array>(symbol);
       for (cell i = 0; i < array_capacity(names); i++) {
         symbol_char* name = alien_offset(array_nth(names, i));
-        void* sym = ffi_dlsym(d, name);
+        cell sym = ffi_dlsym(d, name);
 
         if (sym)
-          return (cell)sym;
+          return sym;
       }
-      return (cell)undefined_symbol;
+      return undefined_symbol;
     }
     default:
       return -1;
@@ -187,30 +183,26 @@ cell factor_vm::compute_dlsym_toc_address(array* parameters, cell index) {
 
   dll* d = (to_boolean(library) ? untag<dll>(library) : NULL);
 
-  void* undefined_toc = (void*)factor::undefined_symbol;
+  cell undefined_toc = (cell)factor::undefined_symbol;
   undefined_toc = FUNCTION_TOC_POINTER(undefined_toc);
   if (d != NULL && !d->handle)
-    return (cell)undefined_toc;
+    return undefined_toc;
 
   switch (tagged<object>(symbol).type()) {
     case BYTE_ARRAY_TYPE: {
       symbol_char* name = alien_offset(symbol);
-      void* toc = ffi_dlsym_toc(d, name);
-      if (toc)
-        return (cell)toc;
-      else
-        return (cell)undefined_toc;
+      cell toc = ffi_dlsym_toc(d, name);
+      return toc ? toc : undefined_toc;
     }
     case ARRAY_TYPE: {
       array* names = untag<array>(symbol);
       for (cell i = 0; i < array_capacity(names); i++) {
         symbol_char* name = alien_offset(array_nth(names, i));
-        void* toc = ffi_dlsym_toc(d, name);
-
+        cell toc = ffi_dlsym_toc(d, name);
         if (toc)
-          return (cell)toc;
+          return toc;
       }
-      return (cell)undefined_toc;
+      return undefined_toc;
     }
     default:
       return -1;

--- a/vm/code_blocks.cpp
+++ b/vm/code_blocks.cpp
@@ -142,73 +142,43 @@ void factor_vm::update_word_references(code_block* compiled,
   }
 }
 
-/* Look up an external library symbol referenced by a compiled code block */
-cell factor_vm::compute_dlsym_address(array* parameters, cell index) {
+/* Look up an external library symbol referenced by a compiled code
+   block */
+cell factor_vm::compute_dlsym_address(array* parameters,
+                                      cell index,
+                                      bool toc) {
   cell symbol = array_nth(parameters, index);
   cell library = array_nth(parameters, index + 1);
+  dll* d = to_boolean(library) ? untag<dll>(library) : NULL;
 
-  dll* d = (to_boolean(library) ? untag<dll>(library) : NULL);
-
-  cell undefined_symbol = (cell)factor::undefined_symbol;
-  undefined_symbol = FUNCTION_CODE_POINTER(undefined_symbol);
+  cell undef = (cell)factor::undefined_symbol;
+  undef = toc ? FUNCTION_TOC_POINTER(undef) : FUNCTION_CODE_POINTER(undef);
   if (d != NULL && !d->handle)
-    return undefined_symbol;
+    return undef;
 
-  switch (tagged<object>(symbol).type()) {
-    case BYTE_ARRAY_TYPE: {
-      symbol_char* name = alien_offset(symbol);
-      cell sym = ffi_dlsym(d, name);
-      return sym ? sym : undefined_symbol;
-    }
-    case ARRAY_TYPE: {
-      array* names = untag<array>(symbol);
-      for (cell i = 0; i < array_capacity(names); i++) {
-        symbol_char* name = alien_offset(array_nth(names, i));
-        cell sym = ffi_dlsym(d, name);
+  cell type = TAG(symbol);
+  if (type == BYTE_ARRAY_TYPE) {
 
-        if (sym)
-          return sym;
-      }
-      return undefined_symbol;
+    symbol_char* name = alien_offset(symbol);
+    cell sym = ffi_dlsym_raw(d, name);
+    sym = toc ? FUNCTION_TOC_POINTER(sym) : FUNCTION_CODE_POINTER(sym);
+    return sym ? sym : undef;
+
+  } else if (type == ARRAY_TYPE) {
+
+    array* names = untag<array>(symbol);
+    for (cell i = 0; i < array_capacity(names); i++) {
+      symbol_char* name = alien_offset(array_nth(names, i));
+      cell sym = ffi_dlsym_raw(d, name);
+      sym = toc ? FUNCTION_TOC_POINTER(sym) : FUNCTION_CODE_POINTER(sym);
+      if (sym)
+        return sym;
     }
-    default:
-      return -1;
+    return undef;
+
   }
+  return -1;
 }
-
-#ifdef FACTOR_PPC
-cell factor_vm::compute_dlsym_toc_address(array* parameters, cell index) {
-  cell symbol = array_nth(parameters, index);
-  cell library = array_nth(parameters, index + 1);
-
-  dll* d = (to_boolean(library) ? untag<dll>(library) : NULL);
-
-  cell undefined_toc = (cell)factor::undefined_symbol;
-  undefined_toc = FUNCTION_TOC_POINTER(undefined_toc);
-  if (d != NULL && !d->handle)
-    return undefined_toc;
-
-  switch (tagged<object>(symbol).type()) {
-    case BYTE_ARRAY_TYPE: {
-      symbol_char* name = alien_offset(symbol);
-      cell toc = ffi_dlsym_toc(d, name);
-      return toc ? toc : undefined_toc;
-    }
-    case ARRAY_TYPE: {
-      array* names = untag<array>(symbol);
-      for (cell i = 0; i < array_capacity(names); i++) {
-        symbol_char* name = alien_offset(array_nth(names, i));
-        cell toc = ffi_dlsym_toc(d, name);
-        if (toc)
-          return toc;
-      }
-      return undefined_toc;
-    }
-    default:
-      return -1;
-  }
-}
-#endif
 
 cell factor_vm::compute_vm_address(cell arg) {
   return (cell)this + untag_fixnum(arg);
@@ -220,7 +190,7 @@ cell factor_vm::lookup_external_address(relocation_type rel_type,
                                         cell index) {
   switch (rel_type) {
     case RT_DLSYM:
-      return compute_dlsym_address(parameters, index);
+      return compute_dlsym_address(parameters, index, false);
     case RT_THIS:
       return compiled->entry_point();
     case RT_MEGAMORPHIC_CACHE_HITS:
@@ -237,7 +207,7 @@ cell factor_vm::lookup_external_address(relocation_type rel_type,
 #endif
 #ifdef FACTOR_PPC
     case RT_DLSYM_TOC:
-      return compute_dlsym_toc_address(parameters, index);
+      return compute_dlsym_address(parameters, index, true);
 #endif
     case RT_INLINE_CACHE_MISS:
       return (cell)&factor::inline_cache_miss;

--- a/vm/contexts.cpp
+++ b/vm/contexts.cpp
@@ -228,12 +228,11 @@ cell factor_vm::datastack_to_array(context* ctx) {
 }
 
 /* Allocates memory */
-void factor_vm::primitive_datastack() { ctx->push(datastack_to_array(ctx)); }
-
-/* Allocates memory */
 void factor_vm::primitive_datastack_for() {
-  context* other_ctx = (context*)pinned_alien_offset(ctx->peek());
-  ctx->replace(datastack_to_array(other_ctx));
+  data_root<alien> alien_ctx(ctx->pop(), this);
+  context* other_ctx = (context*)pinned_alien_offset(alien_ctx.value());
+  cell array = datastack_to_array(other_ctx);
+  ctx->push(array);
 }
 
 /* Allocates memory */
@@ -241,11 +240,6 @@ cell factor_vm::retainstack_to_array(context* ctx) {
   return stack_to_array(ctx->retainstack_seg->start,
                         ctx->retainstack,
                         ERROR_RETAINSTACK_UNDERFLOW);
-}
-
-/* Allocates memory */
-void factor_vm::primitive_retainstack() {
-  ctx->push(retainstack_to_array(ctx));
 }
 
 /* Allocates memory */

--- a/vm/contexts.cpp
+++ b/vm/contexts.cpp
@@ -121,7 +121,7 @@ context* factor_vm::new_context() {
 
 /* Allocates memory */
 void factor_vm::init_context(context* ctx) {
-  ctx->context_objects[OBJ_CONTEXT] = allot_alien(ctx);
+  ctx->context_objects[OBJ_CONTEXT] = allot_alien((cell)ctx);
 }
 
 /* Allocates memory (init_context(), but not parent->new_context() */

--- a/vm/debug.cpp
+++ b/vm/debug.cpp
@@ -299,6 +299,7 @@ void factor_vm::dump_objects(ostream& out, cell type) {
 }
 
 void factor_vm::find_data_references(ostream& out, cell look_for) {
+  primitive_full_gc();
   auto find_data_ref_func = [&](object* obj, cell* slot) {
     if (look_for == *slot) {
       out << padded_address((cell)obj) << " ";
@@ -310,6 +311,7 @@ void factor_vm::find_data_references(ostream& out, cell look_for) {
 }
 
 void factor_vm::dump_edges(ostream& out) {
+  primitive_full_gc();
   auto dump_edges_func = [&](object* obj, cell* scan) {
     if (TAG(*scan) > F_TYPE) {
       out << (void*)tag_dynamic(obj);

--- a/vm/io.cpp
+++ b/vm/io.cpp
@@ -171,8 +171,9 @@ void factor_vm::primitive_fopen() {
   path.untag_check(this);
 
   FILE* file;
-  file = safe_fopen((char*)(path.untagged() + 1), (char*)(mode.untagged() + 1));
-  ctx->push(allot_alien(file));
+  file = safe_fopen((char*)(path.untagged() + 1),
+                    (char*)(mode.untagged() + 1));
+  ctx->push(allot_alien((cell)file));
 }
 
 FILE* factor_vm::pop_file_handle() { return (FILE*)alien_offset(ctx->pop()); }

--- a/vm/os-unix.cpp
+++ b/vm/os-unix.cpp
@@ -47,12 +47,6 @@ cell factor_vm::ffi_dlsym(dll* dll, symbol_char* symbol) {
   return FUNCTION_CODE_POINTER(ffi_dlsym_raw(dll, symbol));
 }
 
-#ifdef FACTOR_PPC
-cell factor_vm::ffi_dlsym_toc(dll* dll, symbol_char* symbol) {
-  return FUNCTION_TOC_POINTER(ffi_dlsym_raw(dll, symbol));
-}
-#endif
-
 void factor_vm::ffi_dlclose(dll* dll) {
   if (dlclose(dll->handle))
     general_error(ERROR_FFI, false_object, false_object);

--- a/vm/os-unix.cpp
+++ b/vm/os-unix.cpp
@@ -39,16 +39,16 @@ void factor_vm::ffi_dlopen(dll* dll) {
   dll->handle = dlopen(alien_offset(dll->path), RTLD_LAZY | RTLD_GLOBAL);
 }
 
-void* factor_vm::ffi_dlsym_raw(dll* dll, symbol_char* symbol) {
-  return dlsym(dll ? dll->handle : null_dll, symbol);
+cell factor_vm::ffi_dlsym_raw(dll* dll, symbol_char* symbol) {
+  return (cell)dlsym(dll ? dll->handle : null_dll, symbol);
 }
 
-void* factor_vm::ffi_dlsym(dll* dll, symbol_char* symbol) {
+cell factor_vm::ffi_dlsym(dll* dll, symbol_char* symbol) {
   return FUNCTION_CODE_POINTER(ffi_dlsym_raw(dll, symbol));
 }
 
 #ifdef FACTOR_PPC
-void* factor_vm::ffi_dlsym_toc(dll* dll, symbol_char* symbol) {
+cell factor_vm::ffi_dlsym_toc(dll* dll, symbol_char* symbol) {
   return FUNCTION_TOC_POINTER(ffi_dlsym_raw(dll, symbol));
 }
 #endif
@@ -384,12 +384,9 @@ void safe_close(int fd) {
 bool check_write(int fd, void* data, ssize_t size) {
   if (write(fd, data, size) == size)
     return true;
-  else {
-    if (errno == EINTR)
-      return check_write(fd, data, size);
-    else
-      return false;
-  }
+  if (errno == EINTR)
+    return check_write(fd, data, size);
+  return false;
 }
 
 void safe_write(int fd, void* data, ssize_t size) {

--- a/vm/os-windows.cpp
+++ b/vm/os-windows.cpp
@@ -14,12 +14,12 @@ void factor_vm::ffi_dlopen(dll* dll) {
   dll->handle = LoadLibraryEx((WCHAR*)alien_offset(dll->path), NULL, 0);
 }
 
-void* factor_vm::ffi_dlsym(dll* dll, symbol_char* symbol) {
-  return (void*)GetProcAddress(dll ? (HMODULE) dll->handle : hFactorDll,
-                               symbol);
+cell factor_vm::ffi_dlsym(dll* dll, symbol_char* symbol) {
+  return (cell)GetProcAddress(dll ? (HMODULE) dll->handle : hFactorDll,
+                              symbol);
 }
 
-void* factor_vm::ffi_dlsym_raw(dll* dll, symbol_char* symbol) {
+cell factor_vm::ffi_dlsym_raw(dll* dll, symbol_char* symbol) {
   return ffi_dlsym(dll, symbol);
 }
 

--- a/vm/primitives.hpp
+++ b/vm/primitives.hpp
@@ -10,11 +10,11 @@ namespace factor {
       _(bignum_gcd) _(bignum_multiply) _(bignum_not) _(bignum_or)              \
       _(bignum_shift) _(bignum_subtract) _(bignum_to_fixnum)                   \
       _(bignum_to_fixnum_strict) _(bignum_xor) _(bits_double) _(bits_float)    \
-      _(byte_array) _(callback) _(callback_room) _(callstack)                  \
+      _(byte_array) _(callback) _(callback_room)                               \
       _(callstack_bounds) _(callstack_for) _(callstack_to_array)               \
       _(check_datastack) _(clear_samples) _(clone) _(code_blocks) _(code_room) \
       _(compact_gc) _(compute_identity_hashcode) _(context_object)             \
-      _(context_object_for) _(current_callback) _(data_room) _(datastack)      \
+      _(context_object_for) _(current_callback) _(data_room)                   \
       _(datastack_for) _(die) _(disable_gc_events) _(dispatch_stats)           \
       _(displaced_alien) _(dlclose) _(dll_validp) _(dlopen) _(dlsym)           \
       _(dlsym_raw) _(double_bits) _(enable_gc_events) _(existsp) _(exit)       \
@@ -29,7 +29,7 @@ namespace factor {
       _(jit_compile) _(load_locals) _(lookup_method) _(mega_cache_miss)        \
       _(minor_gc) _(modify_code_heap) _(nano_count) _(quotation_code)          \
       _(quotation_compiled_p) _(reset_dispatch_stats) _(resize_array)          \
-      _(resize_byte_array) _(resize_string) _(retainstack) _(retainstack_for)  \
+      _(resize_byte_array) _(resize_string) _(retainstack_for)                 \
       _(sampling_profiler) _(save_image) _(set_context_object)                 \
       _(set_datastack) _(set_innermost_stack_frame_quotation)                  \
       _(set_retainstack) _(set_slot) _(set_special_object)                     \

--- a/vm/primitives.hpp
+++ b/vm/primitives.hpp
@@ -39,7 +39,7 @@ namespace factor {
       _(wrapper)
 
 #define EACH_ALIEN_PRIMITIVE(_)                               \
-  _(signed_cell, fixnum, from_signed_cell, to_fixnum)         \
+      _(signed_cell, fixnum, from_signed_cell, to_fixnum)     \
       _(unsigned_cell, cell, from_unsigned_cell, to_cell)     \
       _(signed_8, int64_t, from_signed_8, to_signed_8)        \
       _(unsigned_8, uint64_t, from_unsigned_8, to_unsigned_8) \
@@ -51,7 +51,7 @@ namespace factor {
       _(unsigned_1, uint8_t, from_unsigned_cell, to_cell)     \
       _(float, float, allot_float, to_float)                  \
       _(double, double, allot_float, to_double)               \
-      _(cell, void*, allot_alien, pinned_alien_offset)
+      _(cell, cell, allot_alien, pinned_alien_offset)
 
 #define DECLARE_PRIMITIVE(name) \
   VM_C_API void primitive_##name(factor_vm * parent);

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -659,7 +659,7 @@ struct factor_vm {
   // alien
   char* pinned_alien_offset(cell obj);
   cell allot_alien(cell delegate_, cell displacement);
-  cell allot_alien(void* address);
+  cell allot_alien(cell address);
   void primitive_displaced_alien();
   void primitive_alien_address();
   void* alien_pointer();
@@ -738,10 +738,10 @@ struct factor_vm {
   void move_file(const vm_char* path1, const vm_char* path2);
   void init_ffi();
   void ffi_dlopen(dll* dll);
-  void* ffi_dlsym(dll* dll, symbol_char* symbol);
-  void* ffi_dlsym_raw(dll* dll, symbol_char* symbol);
+  cell ffi_dlsym(dll* dll, symbol_char* symbol);
+  cell ffi_dlsym_raw(dll* dll, symbol_char* symbol);
 #ifdef FACTOR_PPC
-  void* ffi_dlsym_toc(dll* dll, symbol_char* symbol);
+  cell ffi_dlsym_toc(dll* dll, symbol_char* symbol);
 #endif
   void ffi_dlclose(dll* dll);
   void c_to_factor_toplevel(cell quot);

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -171,10 +171,8 @@ struct factor_vm {
   void primitive_set_context_object();
   cell stack_to_array(cell bottom, cell top, vm_error_type error);
   cell datastack_to_array(context* ctx);
-  void primitive_datastack();
   void primitive_datastack_for();
   cell retainstack_to_array(context* ctx);
-  void primitive_retainstack();
   void primitive_retainstack_for();
   cell array_to_stack(array* array, cell bottom);
   void set_datastack(context* ctx, array* array);
@@ -626,7 +624,6 @@ struct factor_vm {
   callstack* allot_callstack(cell size);
   cell second_from_top_stack_frame(context* ctx);
   cell capture_callstack(context* ctx);
-  void primitive_callstack();
   void primitive_callstack_for();
   void primitive_callstack_to_array();
   void primitive_innermost_stack_frame_executing();

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -330,6 +330,17 @@ struct factor_vm {
     gc_off = false;
   }
 
+  template <typename Iterator>
+  inline void each_object_each_slot(Iterator& iterator) {
+    auto each_object_func = [&](object* obj) {
+      auto each_slot_func = [&](cell* slot) {
+        iterator(obj, slot);
+      };
+      obj->each_slot(each_slot_func);
+    };
+    each_object(each_object_func);
+  }
+
   /* the write barrier must be called any time we are potentially storing a
      pointer from an older generation to a younger one */
   inline void write_barrier(cell* slot_ptr) {

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -576,10 +576,7 @@ struct factor_vm {
   cell code_block_owner(code_block* compiled);
   void update_word_references(code_block* compiled, bool reset_inline_caches);
   void undefined_symbol();
-  cell compute_dlsym_address(array* literals, cell index);
-#ifdef FACTOR_PPC
-  cell compute_dlsym_toc_address(array* literals, cell index);
-#endif
+  cell compute_dlsym_address(array* literals, cell index, bool toc);
   cell compute_vm_address(cell arg);
   cell lookup_external_address(relocation_type rel_type,
                                code_block* compiled,
@@ -740,9 +737,6 @@ struct factor_vm {
   void ffi_dlopen(dll* dll);
   cell ffi_dlsym(dll* dll, symbol_char* symbol);
   cell ffi_dlsym_raw(dll* dll, symbol_char* symbol);
-#ifdef FACTOR_PPC
-  cell ffi_dlsym_toc(dll* dll, symbol_char* symbol);
-#endif
   void ffi_dlclose(dll* dll);
   void c_to_factor_toplevel(cell quot);
   void init_signals();


### PR DESCRIPTION
Here is few vm cleanups I've worked on. I removed the `primitive_datastack` primitives because the code can use `primitive_datastack_for` and similar instead.