### PR TITLE
Formatting

### DIFF
--- a/basis/formatting/formatting-docs.factor
+++ b/basis/formatting/formatting-docs.factor
@@ -42,7 +42,7 @@ HELP: printf
     { $list
         { { $snippet "%5s" } " formats a string padding with spaces up to 5 characters wide." }
         { { $snippet "%03d" } " formats an integer padding with zeros up to 3 characters wide." }
-        { { $snippet "%'#5f" } " formats a float padding with " { $snippet "#" } " up to 3 characters wide." }
+        { { $snippet "%'#10f" } " formats a float padding with " { $snippet "#" } " up to 10 characters wide." }
         { { $snippet "%-10d" } " formats an integer to 10 characters wide and left-aligns." }
     }
     $nl

--- a/basis/peg/ebnf/ebnf-docs.factor
+++ b/basis/peg/ebnf/ebnf-docs.factor
@@ -60,12 +60,30 @@ HELP: EBNF:
 
 ARTICLE: "peg.ebnf.strings" "Strings"
 "A string in a rule will match that sequence of characters from the input string. "
+"The string is delimited by matching single or double quotes. "
+"Factor's escape sequences are interpreted: " { $link "escape" } ". "
+"For double quotes delimiters, an escaped double quote doesn't terminate the string. "
 "The AST result from the match is the string itself."
 { $examples
     { $example
        "USING: prettyprint peg.ebnf ;"
        "\"helloworld\" [EBNF rule=\"hello\" \"world\" EBNF] ."
        "V{ \"hello\" \"world\" }"
+    }
+    { $example
+       "USING: prettyprint peg.ebnf ;"
+       "\"AΣ𝄞\" [EBNF rule='\\x41' '\\u{greek-capital-letter-sigma}' '\\u01D11E' EBNF] ."
+       "V{ \"A\" \"Σ\" \"𝄞\" }"
+    }
+    { $example
+       "USING: io peg.ebnf ;"
+       "\"A double quote: \\\"\" [EBNF rule='A double quote: \"' EBNF] print"
+       "A double quote: \""
+    }
+    { $example
+       "USING: io peg.ebnf ;"
+       "\"' and \\\"\" [EBNF rule=\"' and \\\"\" EBNF] print"
+       "' and \""
     }
 } ;
 

--- a/basis/peg/ebnf/ebnf-tests.factor
+++ b/basis/peg/ebnf/ebnf-tests.factor
@@ -124,6 +124,18 @@ IN: peg.ebnf.tests
   "'foo'" identifier-parser parse
 ] unit-test
 
+{ "\"" } [
+  "\"\\\"\"" identifier-parser parse
+] unit-test
+
+{ "\\" } [
+  "\"\\\\\"" identifier-parser parse
+] unit-test
+
+{ "AΣ𝄞" } [
+  "'\\x41\\u{greek-capital-letter-sigma}\\u01D11E'" identifier-parser parse
+] unit-test
+
 { "foo" } [
   "foo" non-terminal-parser parse symbol>>
 ] unit-test

--- a/basis/peg/ebnf/ebnf.factor
+++ b/basis/peg/ebnf/ebnf.factor
@@ -3,7 +3,7 @@
 USING: accessors arrays assocs combinators
 combinators.short-circuit effects io.streams.string kernel make
 math.parser multiline namespaces parser peg peg.parsers
-peg.search quotations sequences splitting stack-checker strings
+peg.search quotations sequences sequences.deep splitting stack-checker strings
 strings.parser summary unicode.categories words ;
 FROM: vocabs.parser => search ;
 FROM: peg.search => replace ;
@@ -120,9 +120,13 @@ C: <ebnf> ebnf
     #! or double quotes. The AST produced is the identifier
     #! between the quotes.
     [
-        [ CHAR: " = not ] satisfy repeat1 "\"" "\"" surrounded-by ,
+        [
+            [ CHAR: \ = ] satisfy
+            [ [ CHAR: " = ] [ CHAR: \ = ] bi or ] satisfy 2seq ,
+            [ CHAR: " = not ] satisfy ,
+        ] choice* repeat1 "\"" "\"" surrounded-by ,
         [ CHAR: ' = not ] satisfy repeat1 "'" "'" surrounded-by ,
-    ] choice* [ >string unescape-string ] action ;
+    ] choice* [ flatten >string unescape-string ] action ;
 
 : non-terminal-parser ( -- parser )
     #! A non-terminal is the name of another rule. It can


### PR DESCRIPTION
Small docs fixes for "formatting" and an enhancement for peg.ebnf to allow to escape double quotes so you can make rules that contain both single and double quotes.