### PR TITLE
Fix clang version pattern

### DIFF
--- a/build-support/factor.sh
+++ b/build-support/factor.sh
@@ -113,7 +113,7 @@ set_md5sum() {
 }
 
 semver_into() {
-	CLANG_RE_OLD="^([0-9]*)\.([0-9]*)-(.*)?$" # 3.3-5
+	CLANG_RE_OLD="^([0-9]*)\.([0-9]*)-?(.*)?$" # 3.3-5
 	RE_SEMVER="^([0-9]*)\.([0-9]*)\.([0-9]*)-?(.*)?$" # 3.3.3-5
 	if [[ $1 =~ $CLANG_RE_OLD ]] ; then
 		export "$2=${BASH_REMATCH[1]}"


### PR DESCRIPTION
'Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn)' was parsed incorrectly.