### PR TITLE
Auto load urls.secure when needed

### DIFF
--- a/basis/urls/urls.factor
+++ b/basis/urls/urls.factor
@@ -4,7 +4,7 @@
 USING: accessors arrays assocs combinators fry hashtables
 io.pathnames io.sockets kernel lexer make math.parser
 namespaces peg.ebnf present sequences splitting strings
-strings.parser urls.encoding vocabs.loader ;
+strings.parser urls.encoding vocabs vocabs.loader ;
 
 IN: urls
 
@@ -187,7 +187,7 @@ PRIVATE>
         [ protocol>> protocol-port ]
         tri or <inet>
     ] [ protocol>> ] bi
-    secure-protocol? [ >secure-addr ] when ;
+    secure-protocol? [ "urls.secure" ensure-vocab-loaded >secure-addr ] when ;
 
 : set-url-addr ( url addr -- url )
     [ host>> >>host ] [ port>> >>port ] bi ;

--- a/core/vocabs/vocabs.factor
+++ b/core/vocabs/vocabs.factor
@@ -161,3 +161,6 @@ M: string require ( vocab -- )
 
 : load-vocab ( name -- vocab )
     [ require ] [ lookup-vocab ] bi ;
+
+: ensure-vocab-loaded ( name -- )
+    dup lookup-vocab [ drop ] [ require ] if ;


### PR DESCRIPTION
Fixes #1493 

Changes:
1. Added new word `ensure-vocab-loaded` in `vocabs`
2. Modified word `url-addr` to ensure `urls.secure` is loaded when word is invoked on secure urls