### PR TITLE
Show persistent border on right clicking presentation gadgets

### DIFF
--- a/basis/ui/gadgets/presentations/presentations.factor
+++ b/basis/ui/gadgets/presentations/presentations.factor
@@ -1,12 +1,15 @@
 ! Copyright (C) 2005, 2009 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors kernel namespaces ui.commands ui.gadgets
-ui.gadgets.buttons ui.gadgets.buttons.private ui.gadgets.menus
-ui.gadgets.status-bar ui.gadgets.worlds ui.gestures
-ui.operations ;
+USING: accessors kernel memoize namespaces ui.commands ui.gadgets
+ui.gadgets.borders ui.gadgets.buttons ui.gadgets.buttons.private
+ui.gadgets.glass ui.gadgets.menus ui.gadgets.status-bar
+ui.gadgets.theme ui.gadgets.worlds ui.gestures
+ui.operations ui.pens.solid ;
 IN: ui.gadgets.presentations
 
 TUPLE: presentation < button object hook ;
+
+TUPLE: presentation-menu < border presentation ;
 
 : invoke-presentation ( presentation command -- )
     [ [ dup hook>> call( presentation -- ) ] [ object>> ] bi ] dip
@@ -33,9 +36,26 @@ M: presentation ungraft*
     dup hand-gadget get-global child? [ dup hide-status ] when
     call-next-method ;
 
+MEMO: selected-pen-boundary ( -- button-pen )
+    roll-button-rollover-border <solid> dup dup f f <button-pen> ;
+
+<PRIVATE
+: setup-presentation ( presentation -- presentation )
+    selected-pen-boundary >>boundary ;
+PRIVATE>
+
+: <presentation-menu> ( presentation target hook -- menu )
+    <operations-menu> presentation-menu new-border
+        swap >>presentation
+        { 0 0 } >>size ;
+
 : show-presentation-menu ( presentation -- )
+    setup-presentation dup
     [ ] [ object>> ] [ dup hook>> curry ] tri
-    show-operations-menu ;
+    <presentation-menu> show-menu ;
+
+M: presentation-menu hide-glass-hook
+    presentation>> button-pen-boundary >>boundary drop ;
 
 presentation H{
     { T{ button-down f f 3 } [ show-presentation-menu ] }


### PR DESCRIPTION
Fixes #1499

This commit introduces a persistent border around `presentation` gadgets by using a `border-pen` that always has a border when the `presentation-menu` becomes visible. The hook `hide-glass-hook` is utilized to reset the border back to its usual value when the menu is dismissed or a menu selection is pressed, so that the original roll-over border is set back on the `presentation` gadget.

To test, ensure to run `"ui.gadgets.presentations" reload` to force the a `reload` on the `presentations` vocabulary.