### PR TITLE
Make Visual Studio Code integration go directly to lines

### DIFF
--- a/basis/editors/visual-studio-code/visual-studio-code.factor
+++ b/basis/editors/visual-studio-code/visual-studio-code.factor
@@ -1,6 +1,7 @@
 ! Copyright (C) 2015 Doug Coleman.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: editors kernel make memoize namespaces system vocabs ;
+USING: editors kernel make math.parser memoize namespaces
+sequences system vocabs ;
 IN: editors.visual-studio-code
 
 SINGLETON: visual-studio-code
@@ -19,7 +20,8 @@ M: macosx find-visual-studio-code-invocation
 
 M: visual-studio-code editor-command ( file line -- command )
     [
-        visual-studio-code-invocation % drop ,
+        visual-studio-code-invocation % "-g" ,
+        number>string ":" glue ,
     ] { } make ;
 
 os windows? [ "editors.visual-studio-code.windows" require ] when


### PR DESCRIPTION
I'm not sure whether this didn't originally exist when @erg wrote this or not, but the `-g` flag seems to work just fine on Windows, Linux, and OS X.